### PR TITLE
Add new GRB strategies

### DIFF
--- a/gtecs/alert/data/cadences.json
+++ b/gtecs/alert/data/cadences.json
@@ -34,6 +34,23 @@
         "rank_change": 10,
         "valid_days": 3
     },
+    "THREE_FIRST": {
+        "num_todo": 3,
+        "wait_hours": 1,
+        "rank_change": 10,
+        "valid_days": 1
+    },
+    "THREE_FIRST_ONE_SECOND_ONE_THIRD": {
+        "num_todo": 5,
+        "wait_hours": [
+            1,
+            1,
+            12,
+            12
+        ],
+        "rank_change": 10,
+        "valid_days": 3
+    },
     "HAMMER_EARLY": {
         "num_todo": 8,
         "wait_hours": 0.25,
@@ -50,6 +67,12 @@
         "delay_days": 0.125,
         "rank_change": 10,
         "valid_days": 2.875
+    },
+    "EARLY_ONLY": {
+        "num_todo": 2,
+        "wait_hours": 1,
+        "rank_change": 10,
+        "valid_days": 0.08333333333333333
     },
     "1H_REPEATED": {
         "num_todo": 99,

--- a/gtecs/alert/data/strategies.json
+++ b/gtecs/alert/data/strategies.json
@@ -104,10 +104,7 @@
     },
     "GRB_SWIFT": {
         "rank": 207,
-        "cadence": [
-            "HAMMER_EARLY",
-            "FOLLOW_LATE"
-        ],
+        "cadence": "EARLY_ONLY",
         "constraints": "NORMAL",
         "exposure_sets": "4x90L",
         "skymap_contour": 0.95,
@@ -116,7 +113,7 @@
     },
     "GRB_FERMI": {
         "rank": 218,
-        "cadence": "MANY_FIRST_ONE_SECOND",
+        "cadence": "THREE_FIRST",
         "constraints": "NORMAL",
         "exposure_sets": "4x90L",
         "skymap_contour": 0.95,
@@ -125,10 +122,7 @@
     },
     "GRB_FERMI_SHORT": {
         "rank": 210,
-        "cadence": [
-            "HAMMER_EARLY",
-            "FOLLOW_LATE"
-        ],
+        "cadence": "THREE_FIRST_ONE_SECOND_ONE_THIRD",
         "constraints": "NORMAL",
         "exposure_sets": "4x90L",
         "skymap_contour": 0.95,


### PR DESCRIPTION
As discussed in the GOTO GRB working group, we could do with dialling back our GRB response.

* Swift: 2 pointings, 1h apart, only valid if within 2h from event time (`EARLY_ONLY`)
* Fermi Long: 3 pointings, 1h apart, only valid for 24h from event time (`THREE_FIRST`)
* Fermi Short: 5 pointings in total; 3 pointings 1h apart as above, 1 the next night, 1 the night after, valid for 3 days since event time (`THREE_FIRST_ONE_SECOND_ONE_THIRD`)

Draft for now until we've confirmed with a few events.
