### PR TITLE
Add GECAM GRB alerts

### DIFF
--- a/gtecs/alert/data/test_notices/GECAM#260-FLT.xml
+++ b/gtecs/alert/data/test_notices/GECAM#260-FLT.xml
@@ -1,0 +1,106 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<voe:VOEvent xmlns:voe="http://www.ivoa.net/xml/VOEvent/v2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ivorn="ivo://nasa.gsfc.gcn/GECAM#FLT_Event_2024-01-12T569:03:04.96_000018-768" role="observation" version="2.0" xsi:schemaLocation="http://www.ivoa.net/xml/VOEvent/v2.0  http://www.ivoa.net/xml/VOEvent/VOEvent-v2.0.xsd">
+  <Who>
+    <AuthorIVORN>ivo://nasa.gsfc.tan/gcn</AuthorIVORN>
+    <Author>
+      <shortName>GECAM (via VO-GCN/TAN)</shortName>
+      <contactName>Yue Huang</contactName>
+      <contactEmail>huangyue@ihep.ac.cn</contactEmail>
+    </Author>
+    <Date>2024-01-12T05:44:54</Date>
+    <Description>This VOEvent message was created with GCN/TAN VOE version: 15.08 17jun22</Description>
+  </Who>
+  <What>
+    <Param name="Packet_Type" dataType="int" value="188"/>
+    <Param name="Pkt_Ser_Num" dataType="int" value="18"/>
+    <Param name="Trigger_Number" dataType="int" value="260" ucd="meta.id"/>
+    <Param name="MISSION" dataType="string" value="B">
+      <Description>Which Mission.</Description>
+    </Param>
+    <Param name="EVENT_DATE" dataType="int" value="20321" unit="days" ucd="time">
+      <Description>Trucated Julian day.</Description>
+    </Param>
+    <Param name="EVENT_TIME" datatype="float" value="20485.850" unit="sec" ucd="time">
+      <Description>Seconds of the Day UT.</Description>
+    </Param>
+    <Param name="TRIGGER_SIGNIF" dataType="float" value=" 4.90" unit="sigma">
+      <Description>Significance of the trigger.</Description>
+    </Param>
+    <Param name="TRIGGER_DUR" dataType="float" value="0.200" unit="sec">
+      <Description>Duration of the trigger criteria that initiated this event.</Description>
+    </Param>
+    <Param name="TRIGGER_ERANGE_LoBin" dataType="int" value="1">
+      <Description>Energy window in channel bins; Low limit.</Description>
+    </Param>
+    <Param name="TRIGGER_ERANGE_HiBin" dataType="int" value="2">
+      <Description>Energy window in channel bins; High limit.</Description>
+    </Param>
+    <Param name="TRIGGER_ERANGE_LoEnergy" dataType="int" value="30">
+      <Description>Energy window in keV; Low limit.</Description>
+    </Param>
+    <Param name="TRIGGER_ERANGE_HiEnergy" dataType="int" value="140">
+      <Description>Energy window in keV; High limit.</Description>
+    </Param>
+    <Param name="TRIGGER_DETS" value="0x1030080">
+      <Description>Enable/Disable the 25 detectors involved.</Description>
+    </Param>
+    <Param name="SRC_CLASS" dataType="string" value="GRB">
+      <Description>The Event Type is a regular GRB.</Description>
+    </Param>
+    <Param name="BURST_INTEN" dataType="int" value="1402" unit="[counts/sec]">
+      <Description>Intensity of the burst in counts/sec.</Description>
+    </Param>
+    <Param name="BURST_DUR" dataType="float" value="4.000" unit="[sec]">
+      <Description>Duration of the event.</Description>
+    </Param>
+    <Param name="Phi" dataType="float" value="1.86">
+      <Description>YET TO DO.</Description>
+    </Param>
+    <Param name="Theta" dataType="float" value="90.77">
+      <Description>YET TO DO.</Description>
+    </Param>
+    <Param name="SC_LAT" dataType="float" value="-27.65">
+      <Description>Spacecraft location.</Description>
+    </Param>
+    <Param name="SC_LONG" dataType="float" value="50.31">
+      <Description>Spacecraft location.</Description>
+    </Param>
+  </What>
+  <WhereWhen>
+    <ObsDataLocation>
+      <ObservatoryLocation id="GEOLUN"/>
+      <ObservationLocation>
+        <AstroCoordSystem id="UTC-FK5-GEO"/>
+        <AstroCoords coord_system_id="UTC-FK5-GEO">
+          <Time unit="s">
+            <TimeInstant>
+              <ISOTime>2024-01-12T05:41:25.85</ISOTime>
+            </TimeInstant>
+          </Time>
+          <Position2D unit="deg">
+            <Name1>RA</Name1>
+            <Name2>Dec</Name2>
+            <Value2>
+              <C1>290.3500</C1>
+              <C2>18.4100</C2>
+            </Value2>
+            <Error2Radius>3.6099</Error2Radius>
+          </Position2D>
+        </AstroCoords>
+      </ObservationLocation>
+    </ObsDataLocation>
+    <Description>The RA,Dec coordinates are of the type: source_object.</Description>
+  </WhereWhen>
+  <How>
+    <Description>GECAM FLIGHT</Description>
+    <Reference uri="http://gcn.gsfc.nasa.gov/gcn/gecam.html" type="url"/>
+  </How>
+  <Why importance="1.0">
+    <Inference probability="1.0">
+      <Concept>process.variation.burst;em</Concept>
+    </Inference>
+  </Why>
+  <Description>
+  </Description>
+</voe:VOEvent>

--- a/gtecs/alert/data/test_notices/GECAM#260-GND.xml
+++ b/gtecs/alert/data/test_notices/GECAM#260-GND.xml
@@ -1,0 +1,84 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<voe:VOEvent xmlns:voe="http://www.ivoa.net/xml/VOEvent/v2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ivorn="ivo://nasa.gsfc.gcn/GECAM#GND_Event_2024-01-12T569:03:04.96_000020-810" role="observation" version="2.0" xsi:schemaLocation="http://www.ivoa.net/xml/VOEvent/v2.0  http://www.ivoa.net/xml/VOEvent/VOEvent-v2.0.xsd">
+  <Who>
+    <AuthorIVORN>ivo://nasa.gsfc.tan/gcn</AuthorIVORN>
+    <Author>
+      <shortName>GECAM (via VO-GCN/TAN)</shortName>
+      <contactName>Yue Huang</contactName>
+      <contactEmail>huangyue@ihep.ac.cn</contactEmail>
+    </Author>
+    <Date>2024-01-12T05:57:06</Date>
+    <Description>This VOEvent message was created with GCN/TAN VOE version: 15.08 17jun22</Description>
+  </Who>
+  <What>
+    <Param name="Packet_Type" dataType="int" value="189"/>
+    <Param name="Pkt_Ser_Num" dataType="int" value="20"/>
+    <Param name="Trigger_Number" dataType="int" value="260" ucd="meta.id"/>
+    <Param name="MISSION" dataType="string" value="B">
+      <Description>Which Mission.</Description>
+    </Param>
+    <Param name="EVENT_DATE" dataType="int" value="20321" unit="days" ucd="time">
+      <Description>Trucated Julian day.</Description>
+    </Param>
+    <Param name="EVENT_TIME" datatype="float" value="20485.850" unit="sec" ucd="time">
+      <Description>Seconds of the Day UT.</Description>
+    </Param>
+    <Param name="SRC_CLASS" dataType="string" value="GRB">
+      <Description>The Event Type is a regular GRB.</Description>
+    </Param>
+    <Param name="BURST_INTEN" dataType="int" value="3655" unit="[counts/sec]">
+      <Description>Intensity of the burst in counts/sec.</Description>
+    </Param>
+    <Param name="BURST_DUR" dataType="float" value="3.000" unit="[sec]">
+      <Description>Duration of the event.</Description>
+    </Param>
+    <Param name="Phi" dataType="float" value="8.09">
+      <Description>YET TO DO.</Description>
+    </Param>
+    <Param name="Theta" dataType="float" value="91.19">
+      <Description>YET TO DO.</Description>
+    </Param>
+    <Param name="SC_LAT" dataType="float" value="-27.65">
+      <Description>Spacecraft location.</Description>
+    </Param>
+    <Param name="SC_LONG" dataType="float" value="50.31">
+      <Description>Spacecraft location.</Description>
+    </Param>
+  </What>
+  <WhereWhen>
+    <ObsDataLocation>
+      <ObservatoryLocation id="GEOLUN"/>
+      <ObservationLocation>
+        <AstroCoordSystem id="UTC-FK5-GEO"/>
+        <AstroCoords coord_system_id="UTC-FK5-GEO">
+          <Time unit="s">
+            <TimeInstant>
+              <ISOTime>2024-01-12T05:41:25.85</ISOTime>
+            </TimeInstant>
+          </Time>
+          <Position2D unit="deg">
+            <Name1>RA</Name1>
+            <Name2>Dec</Name2>
+            <Value2>
+              <C1>351.9100</C1>
+              <C2>1.1900</C2>
+            </Value2>
+            <Error2Radius>1.9299</Error2Radius>
+          </Position2D>
+        </AstroCoords>
+      </ObservationLocation>
+    </ObsDataLocation>
+    <Description>The RA,Dec coordinates are of the type: source_object.</Description>
+  </WhereWhen>
+  <How>
+    <Description>GECAM GROUND</Description>
+    <Reference uri="http://gcn.gsfc.nasa.gov/gcn/gecam.html" type="url"/>
+  </How>
+  <Why importance="1.0">
+    <Inference probability="1.0">
+      <Concept>process.variation.burst;em</Concept>
+    </Inference>
+  </Why>
+  <Description></Description>
+</voe:VOEvent>

--- a/gtecs/alert/data/test_notices/bad_notices/Fermi_no_duration.xml
+++ b/gtecs/alert/data/test_notices/bad_notices/Fermi_no_duration.xml
@@ -1,0 +1,110 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<voe:VOEvent ivorn="ivo://nasa.gsfc.gcn/Fermi#GBM_Fin_Pos2023-11-14T09:18:40.39_721646325_0-551_reingest" role="observation" version="2.0"
+  xmlns:voe="http://www.ivoa.net/xml/VOEvent/v2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOEvent/v2.0  http://www.ivoa.net/xml/VOEvent/VOEvent-v2.0.xsd">
+  <Who>
+    <AuthorIVORN>ivo://nasa.gsfc.tan/gcn</AuthorIVORN>
+    <Author>
+      <shortName>Fermi (via VO-GCN)</shortName>
+      <contactName>Julie McEnery</contactName>
+      <contactPhone>+1-301-286-1632</contactPhone>
+      <contactEmail>Julie.E.McEnery@nasa.gov</contactEmail>
+    </Author>
+    <Date>2023-11-14T12:37:12</Date>
+    <Description>This VOEvent message was created with GCN VOE version: 15.08 17jun22</Description>
+  </Who>
+  <What>
+    <Param name="Packet_Type" value="115"/>
+    <Param name="Pkt_Ser_Num" value="4"/>
+    <Param name="TrigID" value="721646325" ucd="meta.id"/>
+    <Param name="Sequence_Num" value="0" ucd="meta.id.part"/>
+    <Param name="Burst_TJD" value="20262" unit="days" ucd="time"/>
+    <Param name="Burst_SOD" value="33520.39" unit="sec" ucd="time"/>
+    <Param name="Burst_Inten" value="0" unit="cts" ucd="phot.count"/>
+    <Param name="Data_Integ" value="0.000" unit="sec" ucd="time.interval"/>
+    <Param name="Burst_Signif" value="0.00" unit="sigma" ucd="stat.snr"/>
+    <Param name="Phi" value="76.00" unit="deg" ucd="pos.az.azi"/>
+    <Param name="Theta" value="77.00" unit="deg" ucd="pos.az.zd"/>
+    <Param name="Algorithm" value="415" unit="dn"/>
+    <Param name="Lo_Energy" value="50000" unit="keV"/>
+    <Param name="Hi_Energy" value="300000" unit="keV"/>
+    <Param name="Trigger_ID" value="0x00000000"/>
+    <Param name="Misc_flags" value="0x40000001"/>
+    <Group name="Trigger_ID">
+      <Param name="Def_NOT_a_GRB" value="false"/>
+      <Param name="Target_in_Blk_Catalog" value="false"/>
+      <Param name="Human_generated" value="false"/>
+      <Param name="Robo_generated" value="true"/>
+      <Param name="Spatial_Prox_Match" value="false"/>
+      <Param name="Temporal_Prox_Match" value="false"/>
+      <Param name="Test_Submission" value="false"/>
+    </Group>
+    <Group name="Misc_Flags">
+      <Param name="Values_Out_of_Range" value="false"/>
+      <Param name="Flt_Generated" value="false"/>
+      <Param name="Gnd_Generated" value="true"/>
+      <Param name="CRC_Error" value="false"/>
+    </Group>
+    <Param name="LightCurve_URL" value="http://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/triggers/2023/bn231114388/quicklook/glg_lc_medres34_bn231114388.gif" ucd="meta.ref.url"/>
+    <Param name="LocationMap_URL" value="http://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/triggers/2023/bn231114388/quicklook/glg_locplot_all_bn231114388.png" ucd="meta.ref.url"/>
+    <Param name="Coords_Type" value="1" unit="dn"/>
+    <Param name="Coords_String" value="source_object"/>
+    <Group name="Obs_Support_Info">
+      <Description>The Sun and Moon values are valid at the time the VOEvent XML message was created.</Description>
+      <Param name="Sun_RA" value="229.45" unit="deg" ucd="pos.eq.ra"/>
+      <Param name="Sun_Dec" value="-18.23" unit="deg" ucd="pos.eq.dec"/>
+      <Param name="Sun_Distance" value="70.75" unit="deg" ucd="pos.angDistance"/>
+      <Param name="Sun_Hr_Angle" value="5.28" unit="hr"/>
+      <Param name="Moon_RA" value="243.16" unit="deg" ucd="pos.eq.ra"/>
+      <Param name="Moon_Dec" value="-24.55" unit="deg" ucd="pos.eq.dec"/>
+      <Param name="MOON_Distance" value="77.81" unit="deg" ucd="pos.angDistance"/>
+      <Param name="Moon_Illum" value="1.47" unit="%" ucd="arith.ratio"/>
+      <Param name="Galactic_Long" value="268.55" unit="deg" ucd="pos.galactic.lon"/>
+      <Param name="Galactic_Lat" value="14.63" unit="deg" ucd="pos.galactic.lat"/>
+      <Param name="Ecliptic_Long" value="169.29" unit="deg" ucd="pos.ecliptic.lon"/>
+      <Param name="Ecliptic_Lat" value="-44.92" unit="deg" ucd="pos.ecliptic.lat"/>
+    </Group>
+    <Description>The Fermi-GBM location of a transient.</Description>
+  </What>
+  <WhereWhen>
+    <ObsDataLocation>
+      <ObservatoryLocation id="GEOLUN"/>
+      <ObservationLocation>
+        <AstroCoordSystem id="UTC-FK5-GEO"/>
+        <AstroCoords coord_system_id="UTC-FK5-GEO">
+          <Time unit="s">
+            <TimeInstant>
+              <ISOTime>2023-11-14T09:18:40.39</ISOTime>
+            </TimeInstant>
+          </Time>
+          <Position2D unit="deg">
+            <Name1>RA</Name1>
+            <Name2>Dec</Name2>
+            <Value2>
+              <C1>150.0000</C1>
+              <C2>-36.5499</C2>
+            </Value2>
+            <Error2Radius>11.3800</Error2Radius>
+          </Position2D>
+        </AstroCoords>
+      </ObservationLocation>
+    </ObsDataLocation>
+    <Description>The RA,Dec coordinates are of the type: source_object.</Description>
+  </WhereWhen>
+  <How>
+    <Description>Fermi Satellite, GBM Instrument</Description>
+    <Reference uri="http://gcn.gsfc.nasa.gov/fermi.html" type="url"/>
+  </How>
+  <Why importance="0.95">
+    <Inference probability="1.0">
+      <Concept>process.variation.burst;em.gamma</Concept>
+    </Inference>
+  </Why>
+  <Citations>
+    <EventIVORN cite="followup">ivo://nasa.gsfc.gcn/Fermi#GBM_Alert_2023-11-14T09:18:40.39_721646325_1-848</EventIVORN>
+    <Description>This is an updated position to the original trigger.</Description>
+  </Citations>
+  <Description>
+  </Description>
+</voe:VOEvent>
+

--- a/gtecs/alert/data/test_notices/bad_notices/Swift_lost_lock.xml
+++ b/gtecs/alert/data/test_notices/bad_notices/Swift_lost_lock.xml
@@ -1,0 +1,146 @@
+<?xml version = '1.0' encoding = 'UTF-8'?>
+<voe:VOEvent ivorn="ivo://nasa.gsfc.gcn/SWIFT#BAT_GRB_Pos_1209406-601" role="observation" version="2.0"
+    xmlns:voe="http://www.ivoa.net/xml/VOEvent/v2.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOEvent/v2.0  http://www.ivoa.net/xml/VOEvent/VOEvent-v2.0.xsd">
+    <Who>
+        <AuthorIVORN>ivo://nasa.gsfc.tan/gcn</AuthorIVORN>
+        <Author>
+            <shortName>VO-GCN</shortName>
+            <contactName>Scott Barthelmy</contactName>
+            <contactPhone>+1-301-286-3106</contactPhone>
+            <contactEmail>scott.barthelmy@nasa.gov</contactEmail>
+        </Author>
+        <Date>2024-01-17T16:51:33</Date>
+        <Description>This VOEvent message was created with GCN VOE version: 15.08 17jun22</Description>
+    </Who>
+    <What>
+        <Param name="Packet_Type" value="61" />
+        <Param name="Pkt_Ser_Num" value="31" />
+        <Param name="TrigID" value="1209406" ucd="meta.id" />
+        <Param name="Segment_Num" value="0" ucd="meta.id.part" />
+        <Param name="Burst_TJD" value="20326" unit="days" ucd="time" />
+        <Param name="Burst_SOD" value="60503.25" unit="sec" ucd="time" />
+        <Param name="Burst_Inten" value="0" unit="cts" ucd="phot.count;em.gamma.soft" />
+        <Param name="Burst_Peak" value="4940" unit="cts" ucd="phot.count;em.gamma.soft" />
+        <Param name="Integ_Time" value="80.000" unit="sec" ucd="time.interval" />
+        <Param name="Phi" value="83.95" unit="deg" ucd="pos.az.azi" />
+        <Param name="Theta" value="0.20" unit="deg" ucd="pos.az.zd" />
+        <Param name="Trig_Index" value="20000" />
+        <Param name="Soln_Status" value="0x413" />
+        <Param name="Misc_flags" value="0x1200000" />
+        <Param name="Cat_Num" value="0" />
+        <Param name="Rate_Signif" value="0.00" unit="sigma" ucd="stat.snr" />
+        <Param name="Image_Signif" value="17.05" unit="sigma" ucd="stat.snr" />
+        <Param name="Bkg_Inten" value="0" unit="cts" ucd="phot.count" />
+        <Param name="Bkg_Time" value="00:00:00.00" ucd="time.start" />
+        <Param name="Bkg_Dur" value="0.00" unit="sec" ucd="time.duration" />
+        <Param name="SC_Long" value="89.96" unit="deg" ucd="pos.earth.lon" />
+        <Param name="SC_Lat" value="-20.36" unit="deg" ucd="pos.earth.lat" />
+        <Group name="Merit_Values">
+            <Param name="Merit_Val0" value="1" unit="dn" />
+            <Param name="Merit_Val1" value="0" unit="dn" />
+            <Param name="Merit_Val2" value="0" unit="dn" />
+            <Param name="Merit_Val3" value="6" unit="dn" />
+            <Param name="Merit_Val4" value="1" unit="dn" />
+            <Param name="Merit_Val5" value="5" unit="dn" />
+            <Param name="Merit_Val6" value="0" unit="dn" />
+            <Param name="Merit_Val7" value="1" unit="dn" />
+            <Param name="Merit_Val8" value="83" unit="dn" />
+            <Param name="Merit_Val9" value="0" unit="dn" />
+        </Group>
+        <Group name="Solution_Status">
+            <Param name="Point_Source" value="true" />
+            <Param name="GRB_Identified" value="true" />
+            <Param name="Target_of_Interest" value="false" />
+            <Param name="Target_Imag_Trig" value="true" />
+            <Param name="Target_Rate_Trig" value="false" />
+            <Param name="Def_NOT_a_GRB" value="false" />
+            <Param name="Hi_Bkg_Level" value="false" />
+            <Param name="Neg_Bkg_Slope" value="false" />
+            <Param name="Lo_Image_Signif" value="false" />
+            <Param name="VERY_Lo_Image_Signif" value="false" />
+            <Param name="Target_in_Flt_Catalog" value="false" />
+            <Param name="Target_in_Gnd_Catalog" value="false" />
+            <Param name="Target_in_Blk_Catalog" value="false" />
+            <Param name="StarTrack_Lost_Lock" value="true" />
+            <Param name="Near_Bright_Star" value="false" />
+            <Param name="Src_Removed_from_OnBoard" value="false" />
+            <Param name="Converted_SubThresh" value="false" />
+            <Param name="Spatial_Prox_Match" value="false" />
+            <Param name="Temporal_Prox_Match" value="false" />
+            <Param name="Test_Submission" value="false" />
+        </Group>
+        <Group name="Misc_Flags">
+            <Param name="Values_Out_of_Range" value="false" />
+            <Param name="Already_Observing_Position" value="false" />
+            <Param name="Near_Bright_Star" value="false" />
+            <Param name="Err_Circle_in_Galaxy" value="false" />
+            <Param name="Galaxy_in_Err_Circle" value="false" />
+            <Param name="ImTrig_during_ST_LoL" value="true" />
+            <Param name="TOO_Generated" value="false" />
+            <Param name="Trig_time_is_SecHdrTime" value="false" />
+            <Param name="Delayed_Transmission" value="true" />
+            <Param name="Updated_Notice" value="false" />
+            <Param name="Flt_Generated" value="true" />
+            <Param name="Gnd_Generated" value="false" />
+            <Param name="SERS_Generated" value="false" />
+            <Param name="Other_Generated" value="false" />
+            <Param name="CRC_Error" value="false" />
+        </Group>
+        <Param name="Coords_Type" value="1" unit="dn" />
+        <Param name="Coords_String" value="source_object" />
+        <Group name="Obs_Support_Info">
+            <Description>The Sun and Moon values are valid at the time the VOEvent XML message was created.</Description>
+            <Param name="Sun_RA" value="299.11" unit="deg" ucd="pos.eq.ra" />
+            <Param name="Sun_Dec" value="-20.74" unit="deg" ucd="pos.eq.dec" />
+            <Param name="Sun_Distance" value="147.41" unit="deg" ucd="pos.angDistance" />
+            <Param name="Sun_Hr_Angle" value="-9.66" unit="hr" />
+            <Param name="Moon_RA" value="19.48" unit="deg" ucd="pos.eq.ra" />
+            <Param name="Moon_Dec" value="8.25" unit="deg" ucd="pos.eq.dec" />
+            <Param name="MOON_Distance" value="63.40" unit="deg" ucd="pos.angDistance" />
+            <Param name="Moon_Illum" value="44.89" unit="%" ucd="arith.ratio" />
+            <Param name="Galactic_Long" value="184.31" unit="deg" ucd="pos.galactic.lon" />
+            <Param name="Galactic_Lat" value="-5.58" unit="deg" ucd="pos.galactic.lat" />
+            <Param name="Ecliptic_Long" value="84.15" unit="deg" ucd="pos.ecliptic.lon" />
+            <Param name="Ecliptic_Lat" value="-0.98" unit="deg" ucd="pos.ecliptic.lat" />
+        </Group>
+        <Description>Type=61: The Swift-BAT instrument position notice.</Description>
+    </What>
+    <WhereWhen>
+        <ObsDataLocation>
+            <ObservatoryLocation id="GEOLUN" />
+            <ObservationLocation>
+                <AstroCoordSystem id="UTC-FK5-GEO" />
+                <AstroCoords coord_system_id="UTC-FK5-GEO">
+                    <Time unit="s">
+                        <TimeInstant>
+                            <ISOTime>2024-01-17T16:48:23.25</ISOTime>
+                        </TimeInstant>
+                    </Time>
+                    <Position2D unit="deg">
+                        <Name1>RA</Name1>
+                        <Name2>Dec</Name2>
+                        <Value2>
+                            <C1>83.6790</C1>
+                            <C2>22.3339</C2>
+                        </Value2>
+                        <Error2Radius>0.0500</Error2Radius>
+                    </Position2D>
+                </AstroCoords>
+            </ObservationLocation>
+        </ObsDataLocation>
+        <Description>The RA,Dec coordinates are of the type: source_object.</Description>
+    </WhereWhen>
+    <How>
+        <Description>Swift Satellite, BAT Instrument</Description>
+        <Reference uri="http://gcn.gsfc.nasa.gov/swift.html" type="url" />
+    </How>
+    <Why importance="0.90">
+        <Inference probability="0.90">
+            <Name>GRB 240117</Name>
+            <Concept>process.variation.burst;em.gamma</Concept>
+        </Inference>
+    </Why>
+    <Description>
+    </Description>
+</voe:VOEvent>

--- a/gtecs/alert/gcn.py
+++ b/gtecs/alert/gcn.py
@@ -290,7 +290,7 @@ class GWNotice(GCNNotice):
                 'time_sky_position_coincidence_far':
                     float(external_group['Time_Sky_Position_Coincidence_FAR']['value']),
                 'combined_skymap_url': external_group['joint_skymap_fits']['value'],
-                }
+            }
             # Override the skymap URL with the combined skymap
             self.skymap_url_original = self.skymap_url
             self.skymap_url = self.external['combined_skymap_url']
@@ -553,6 +553,7 @@ class GRBNotice(GCNNotice):
     VALID_PACKET_TYPES = {
         115: 'FERMI_GBM_FIN_POS',
         61: 'SWIFT_BAT_GRB_POS',
+        189: 'GECAM_GND',
     }
 
     def __init__(self, payload):
@@ -561,7 +562,9 @@ class GRBNotice(GCNNotice):
             raise ValueError(f'GCN packet type {self.packet_id} not valid for this class')
         self.packet_type = self.VALID_PACKET_TYPES[self.packet_id]
         self.event_type = 'GRB'
-        self.event_source = self.packet_type.split('_')[0].capitalize()
+        self.event_source = self.packet_type.split('_')[0]
+        if self.event_source in ['FERMI', 'SWIFT']:
+            self.event_source = self.event_source.capitalize()
 
         # Get XML param dicts
         # NB: you can't store these on the class because they're unpickleable.
@@ -569,7 +572,10 @@ class GRBNotice(GCNNotice):
         group_params = vp.get_grouped_params(self.voevent)
 
         # Get info from the VOEvent
-        self.event_id = top_params['TrigID']['value']  # e.g. 579943502
+        try:
+            self.event_id = top_params['TrigID']['value']  # Fermi & Swift
+        except KeyError:
+            self.event_id = top_params['Trigger_Number']['value']  # GECAM
         self.event_name = '{}_{}'.format(self.event_source, self.event_id)  # e.g. Fermi_579943502
         if self.event_source == 'Fermi':
             self.properties = {key: group_params['Trigger_ID'][key]['value']
@@ -583,6 +589,10 @@ class GRBNotice(GCNNotice):
         elif self.event_source == 'Swift':
             self.properties = {key: group_params['Solution_Status'][key]['value']
                                for key in group_params['Solution_Status']}
+        elif self.event_source == 'GECAM':
+            self.properties = {'class': top_params['SRC_CLASS']['value']}
+            if self.properties['class'] != 'GRB':
+                raise ValueError('GECAM notice is not a GRB ({})'.format(self.properties['class']))
         else:
             raise ValueError(f'Unknown GRB source {self.event_source}')
         for key in self.properties:
@@ -621,6 +631,8 @@ class GRBNotice(GCNNotice):
                 return 'GRB_FERMI_SHORT'
             else:
                 return 'GRB_FERMI'
+        elif self.event_source == 'GECAM':
+            return 'GRB_FERMI'  # Just use the default Fermi strategy
         else:
             raise ValueError(f'Unknown GRB source: "{self.event_source}"')
 

--- a/gtecs/alert/gcn.py
+++ b/gtecs/alert/gcn.py
@@ -627,7 +627,7 @@ class GRBNotice(GCNNotice):
         if self.event_source == 'Swift':
             return 'GRB_SWIFT'
         elif self.event_source == 'Fermi':
-            if self.duration.lower() == 'short':
+            if self.duration.lower() in ['short', 'unknown']:  # Safe side for unknown events
                 return 'GRB_FERMI_SHORT'
             else:
                 return 'GRB_FERMI'

--- a/gtecs/alert/handler.py
+++ b/gtecs/alert/handler.py
@@ -8,7 +8,6 @@ from astropy.time import Time
 from gtecs.obs import database as obs_db
 
 from . import database as alert_db
-from . import params
 from .slack import send_notice_report, send_observing_report, send_slack_msg
 
 
@@ -232,11 +231,11 @@ def add_to_database(notice, time=None, log=None):
                 )
             )
 
-        # Add everything to the database
-        log.debug('Adding {} Targets to the database'.format(len(db_targets)))
-        obs_db.insert_items(session, db_targets)
+            # Add the target to the database (and all related entries)
+            session.add(db_targets[-1])
 
         # Commit changes
+        log.debug('Adding {} Targets to the database'.format(len(db_targets)))
         try:
             session.commit()
         except Exception:
@@ -282,7 +281,7 @@ def handle_notice(notice, send_messages=False, log=None, time=None):
         except Exception as err:
             log.exception('Error sending notice report')
             try:
-                msg = 'Error sending notice report ("{err.__class__.__name__}: {err}")'
+                msg = f'Error sending notice report ("{err.__class__.__name__}: {err}")'
                 send_slack_msg(msg)
             except Exception:
                 log.exception('Error sending error report')
@@ -294,7 +293,7 @@ def handle_notice(notice, send_messages=False, log=None, time=None):
         log.debug('Sending Slack observing report')
         try:
             send_observing_report(notice, time=time)
-        except Exception:
+        except Exception as err:
             log.exception('Error sending observing report')
             try:
                 msg = f'Error sending observing report ("{err.__class__.__name__}: {err}")'


### PR DESCRIPTION
This PR adds GRB alerts from the [Gravitational Wave High-energy Electromagnetic Counterpart All-sky Monitor (GECAM)](https://gcn.nasa.gov/missions/gecam#gravitational-wave-high-energy-electromagnetic-counterpart-all-sky-monitor-gecam) project. GECAM puts out both flight and ground alerts, but a basic analysis shows that there can be quite a change of localisation between the two. So we'll stick to the later ground alerts, but I added an example flight alert too.

Closes #76 

I also made a few bug fixes, changed the default Fermi strategy to use the "short" strategy in cases where the duration parameter is missing (the decision was better to "waste" time on a long burst than miss out on a short one - see #wg-grbs 2023-11-14) and filtered out Swift alerts when the telescope has lost the star lock (see #wg-grbs 2024-01-17). I've added examples of both to a "bad_notices" directory.