### PR TITLE
Process AMON IceCube alerts correctly

### DIFF
--- a/gtecs/alert/notices.py
+++ b/gtecs/alert/notices.py
@@ -257,8 +257,12 @@ class Notice:
                 return GECAMNotice(message)
             elif base_notice.source.upper() == 'EINSTEIN_PROBE':
                 return EinsteinProbeNotice(message)
-            elif base_notice.source.upper() == 'ICECUBE':
-                return IceCubeNotice(message)
+            elif base_notice.source.upper() == 'AMON':
+                # AMON is the "Astrophysical Multimessenger Observatory Network",
+                # and there are several different types of notices they produce.
+                # For now we only care about the IceCube neutrino alerts.
+                if hasattr(base_notice, 'ivorn') and 'ICECUBE' in base_notice.ivorn:
+                    return IceCubeNotice(message)
         except InvalidNoticeError:
             # For whatever reason the notice isn't valid, so fall back to the default class
             pass
@@ -1072,10 +1076,10 @@ class IceCubeNotice(Notice):
         super().__init__(payload)
 
         # Check source
-        if self.source.upper() != 'ICECUBE':
-            raise InvalidNoticeError(f'Invalid source for Neutrino notice: "{self.source}"')
-        if self.source == 'ICECUBE':
-            self.source = 'IceCube'  # For nice formatting
+        # Note IceCube uses 'AMON' as the source for all notices
+        if self.source.upper() != 'AMON':
+            raise InvalidNoticeError(f'Invalid source for IceCube notice: "{self.source}"')
+        self.source = 'IceCube'  # For nice formatting
 
         # Event properties
         self.event_type = 'NU'

--- a/gtecs/alert/sentinel.py
+++ b/gtecs/alert/sentinel.py
@@ -527,7 +527,10 @@ class Sentinel:
 
     def clear_queue(self):
         """Clear the current notice queue."""
+        queue_length = len(self.notice_queue)
+        self.log.info(f'Clearing {queue_length} notices from queue')
         self.notice_queue = []
+        return queue_length
 
 
 def run():

--- a/scripts/sentinel
+++ b/scripts/sentinel
@@ -77,8 +77,8 @@ def query(command, args):
                 print(i, ivorn)
         elif len(args) == 1 and args[0] == 'clear':
             with Pyro4.Proxy(params.PYRO_URI) as proxy:
-                proxy.clear_queue()
-                print('Queue cleared')
+                queue_length = proxy.clear_queue()
+                print(f'Cleared {queue_length} notices from the queue')
         else:
             print('ERROR: Invalid arguments for "queue" command')
             print('Usage: sentinel queue [clear]')


### PR DESCRIPTION
The update to the sentinel in #84 broke IceCube alerts, because the source flag is actually `AMON` (https://www.amon.psu.edu/). This PR fixes that issue so IceCube alerts are handled correctly.