### PR TITLE
Add SVOM alerts

### DIFF
--- a/gtecs/alert/data/test_notices/EinsteinProbe/10202399251-WXT-tiny_error.json
+++ b/gtecs/alert/data/test_notices/EinsteinProbe/10202399251-WXT-tiny_error.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://gcn.nasa.gov/schema/v4.1.0/gcn/notices/einstein_probe/wxt/alert.schema.json",
+    "instrument": "WXT",
+    "trigger_time": "2025-02-12T07:45:33.00Z",
+    "id": [
+        "10202399251"
+    ],
+    "ra": 114.9852,
+    "dec": 60.4872,
+    "ra_dec_error": 0.006,
+    "image_energy_range": [
+        0.5,
+        4
+    ],
+    "net_count_rate": 0.2,
+    "image_snr": 11,
+    "additional_info": "The net count rate is derived from an accumulated image (up to 20 min) in 0.5-4 keV, assuming a constant flux. However, it can be significantly lower than the actual count rate of a burst with a duration much shorter than 20 min."
+}

--- a/gtecs/alert/data/test_notices/SVOM/sb25030804-GRM_TRIGGER.xml
+++ b/gtecs/alert/data/test_notices/SVOM/sb25030804-GRM_TRIGGER.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<voe:VOEvent xmlns:voe="http://www.ivoa.net/xml/VOEvent/v2.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOEvent/v2.0 http://www.ivoa.net/xml/VOEvent/VOEvent-v2.0.xsd" role="observation" version="2.0" ivorn="ivo://org.svom/fsc#sb25030804_grm-trigger">
+    <Who>
+        <AuthorIVORN>ivo://org.svom/FSC</AuthorIVORN>
+        <Date>2025-03-08T18:16:59</Date>
+        <Author>
+            <title>SVOM French Science Center</title>
+            <shortName>FSC</shortName>
+            <contactName>Timothe Roland</contactName>
+            <contactEmail>svom-contact@cea.fr</contactEmail>
+        </Author>
+    </Who>
+    <What>
+        <Param name="Packet_Type" value="201" ucd="meta.id"/>
+        <Param name="Pkt_Ser_Num" value="1" ucd="meta.id"/>
+        <Param name="Instrument" value="GRM" ucd="instr"/>
+        <Group name="Svom_Identifiers">
+            <Param name="Notice_Level" value="N1g" ucd="meta.id"/>
+            <Param name="Burst_Id" value="sb25030804" ucd="meta.id"/>
+        </Group>
+        <Group name="Detection_Info">
+            <Param name="SNR" value="40.10" unit="sigma" ucd="stat.snr"/>
+            <Param name="Timescale" value="0.1" unit="s" ucd="time.interval"/>
+            <Param name="Time_Window_Start" value="2025-03-08T18:06:30.900Z" ucd="time.start"/>
+            <Param name="Time_Window_End" value="2025-03-08T18:06:31.000Z" ucd="time.end"/>
+            <Param name="Lower_Energy_Bound" value="51.236435" unit="keV" ucd="em.energy"/>
+            <Param name="Upper_Energy_Bound" value="264.7216" unit="keV" ucd="em.energy"/>
+            <Param name="Triggered_GRDs" value="111" ucd="instr.param"/>
+        </Group>
+        <Group name="Target_Info">
+            <Param name="Galactic_Lon" value="233.93" unit="deg" ucd="pos.galactic.lon"/>
+            <Param name="Galactic_Lat" value="50.54" unit="deg" ucd="pos.galactic.lat"/>
+            <Param name="Moon_Angle" value="51.03" unit="deg" ucd="pos.angDistance"/>
+            <Param name="Sun_Angle" value="166.48" unit="deg" ucd="pos.angDistance"/>
+        </Group>
+        <Group name="Satellite_Info">
+            <Param name="Attitude_Ra" value="210.89" unit="deg" ucd="instr.param"/>
+            <Param name="Attitude_Dec" value="21.64" unit="deg" ucd="instr.param"/>
+            <Param name="Attitude_Roll" value="286.21" unit="deg" ucd="instr.param"/>
+        </Group>
+    </What>
+    <WhereWhen>
+        <ObsDataLocation>
+            <ObservatoryLocation id="GEOLEO"/>
+            <ObservationLocation>
+                <AstroCoordSystem id="UTC-ICRS-GEO"/>
+                <AstroCoords coord_system_id="UTC-ICRS-GEO">
+                    <Time unit="s">
+                        <TimeInstant>
+                            <ISOTime>2025-03-08T18:06:30.900000</ISOTime>
+                        </TimeInstant>
+                    </Time>
+                    <Position2D unit="deg">
+                        <Name1>RA</Name1>
+                        <Name2>Dec</Name2>
+                        <Value2>
+                            <C1>155.9861</C1>
+                            <C2>8.5888</C2>
+                        </Value2>
+                        <Error2Radius>-1.0000</Error2Radius>
+                    </Position2D>
+                </AstroCoords>
+            </ObservationLocation>
+        </ObsDataLocation>
+    </WhereWhen>
+    <Why importance="1.00">
+        <Inference probability="1.00">
+            <Concept>process.variation.burst;em.gamma</Concept>
+        </Inference>
+    </Why>
+    <How>
+        <Description>N1g notice, data from GRM</Description>
+        <Reference uri="https://www.svom.eu/en/grm-gamma-ray-burst-monitor-en/"/>
+    </How>
+</voe:VOEvent>

--- a/gtecs/alert/data/test_notices/SVOM/sb25031101-ECLAIRS_WAKEUP.xml
+++ b/gtecs/alert/data/test_notices/SVOM/sb25031101-ECLAIRS_WAKEUP.xml
@@ -1,0 +1,80 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<voe:VOEvent xmlns:voe="http://www.ivoa.net/xml/VOEvent/v2.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOEvent/v2.0 http://www.ivoa.net/xml/VOEvent/VOEvent-v2.0.xsd" role="observation" version="2.0" ivorn="ivo://org.svom/fsc#sb25031101_eclairs-wakeup">
+    <Who>
+        <AuthorIVORN>ivo://org.svom/FSC</AuthorIVORN>
+        <Date>2025-03-11T07:26:09</Date>
+        <Author>
+            <title>SVOM French Science Center</title>
+            <shortName>FSC</shortName>
+            <contactName>Timothe Roland</contactName>
+            <contactEmail>svom-contact@cea.fr</contactEmail>
+        </Author>
+    </Who>
+    <What>
+        <Param name="Packet_Type" value="202" ucd="meta.id"/>
+        <Param name="Pkt_Ser_Num" value="1" ucd="meta.id"/>
+        <Param name="Instrument" value="ECLAIRs" ucd="instr"/>
+        <Group name="Svom_Identifiers">
+            <Param name="Notice_Level" value="N1e" ucd="meta.id"/>
+            <Param name="Burst_Id" value="sb25031101" ucd="meta.id"/>
+        </Group>
+        <Group name="Detection_Info">
+            <Param name="SNR" value="7.45" unit="sigma" ucd="stat.snr"/>
+            <Param name="Timescale" value="10.2" unit="s" ucd="time.interval"/>
+            <Param name="Time_Window_Start" value="2025-03-11T07:08:05.065Z" ucd="time.start"/>
+            <Param name="Time_Window_End" value="2025-03-11T07:08:15.265Z" ucd="time.end"/>
+            <Param name="Lower_Energy_Bound" value="8" unit="keV" ucd="em.energy"/>
+            <Param name="Upper_Energy_Bound" value="120" unit="keV" ucd="em.energy"/>
+            <Param name="Trigger_Type" value="CRT" ucd="instr.param"/>
+        </Group>
+        <Group name="Target_Info">
+            <Param name="Galactic_Lon" value="197.78" unit="deg" ucd="pos.galactic.lon"/>
+            <Param name="Galactic_Lat" value="49.77" unit="deg" ucd="pos.galactic.lat"/>
+            <Param name="Moon_Angle" value="12.36" unit="deg" ucd="pos.angDistance"/>
+            <Param name="Sun_Angle" value="145.05" unit="deg" ucd="pos.angDistance"/>
+        </Group>
+        <Group name="Satellite_Info">
+            <Param name="Slew_Status" value="not-requested" ucd="meta.code.status"/>
+            <Param name="Attitude_Ra" value="163.06" unit="deg" ucd="instr.param"/>
+            <Param name="Attitude_Dec" value="5.92" unit="deg" ucd="instr.param"/>
+            <Param name="Attitude_Roll" value="75.57" unit="deg" ucd="instr.param"/>
+            <Param name="Sat_Longitude" value="-132.08" unit="deg" ucd="pos.earth.lon"/>
+            <Param name="Sat_Latitude" value="-8.21" unit="deg" ucd="pos.earth.lat"/>
+            <Param name="Sat_Altitude" value="620.29" unit="km" ucd="pos.earth.altitude"/>
+        </Group>
+    </What>
+    <WhereWhen>
+        <ObsDataLocation>
+            <ObservatoryLocation id="GEOLEO"/>
+            <ObservationLocation>
+                <AstroCoordSystem id="UTC-ICRS-GEO"/>
+                <AstroCoords coord_system_id="UTC-ICRS-GEO">
+                    <Time unit="s">
+                        <TimeInstant>
+                            <ISOTime>2025-03-11T07:08:05.065000</ISOTime>
+                        </TimeInstant>
+                    </Time>
+                    <Position2D unit="deg">
+                        <Name1>RA</Name1>
+                        <Name2>Dec</Name2>
+                        <Value2>
+                            <C1>146.8848</C1>
+                            <C2>29.8907</C2>
+                        </Value2>
+                        <Error2Radius>0.1755</Error2Radius>
+                    </Position2D>
+                </AstroCoords>
+            </ObservationLocation>
+        </ObsDataLocation>
+    </WhereWhen>
+    <Why importance="0.74">
+        <Inference probability="0.74">
+            <Concept>process.variation.burst;em.gamma</Concept>
+        </Inference>
+    </Why>
+    <How>
+        <Description>N1e notice, data from ECLAIRs</Description>
+        <Reference uri="https://www.svom.eu/en/telescope-eclairs-en/"/>
+    </How>
+</voe:VOEvent>

--- a/gtecs/alert/data/test_notices/SVOM/sb25031103-GRM_TRIGGER-no_coords.xml
+++ b/gtecs/alert/data/test_notices/SVOM/sb25031103-GRM_TRIGGER-no_coords.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<voe:VOEvent xmlns:voe="http://www.ivoa.net/xml/VOEvent/v2.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOEvent/v2.0 http://www.ivoa.net/xml/VOEvent/VOEvent-v2.0.xsd" role="observation" version="2.0" ivorn="ivo://org.svom/fsc#sb25031103_grm-trigger">
+    <Who>
+        <AuthorIVORN>ivo://org.svom/FSC</AuthorIVORN>
+        <Date>2025-03-11T20:57:05</Date>
+        <Author>
+            <title>SVOM French Science Center</title>
+            <shortName>FSC</shortName>
+            <contactName>Timothe Roland</contactName>
+            <contactEmail>svom-contact@cea.fr</contactEmail>
+        </Author>
+    </Who>
+    <What>
+        <Param name="Packet_Type" value="201" ucd="meta.id"/>
+        <Param name="Pkt_Ser_Num" value="1" ucd="meta.id"/>
+        <Param name="Instrument" value="GRM" ucd="instr"/>
+        <Group name="Svom_Identifiers">
+            <Param name="Notice_Level" value="N1g" ucd="meta.id"/>
+            <Param name="Burst_Id" value="sb25031103" ucd="meta.id"/>
+        </Group>
+        <Group name="Detection_Info">
+            <Param name="SNR" value="7.20" unit="sigma" ucd="stat.snr"/>
+            <Param name="Timescale" value="1.0" unit="s" ucd="time.interval"/>
+            <Param name="Time_Window_Start" value="2025-03-11T20:41:47.000Z" ucd="time.start"/>
+            <Param name="Time_Window_End" value="2025-03-11T20:41:48.000Z" ucd="time.end"/>
+            <Param name="Lower_Energy_Bound" value="51.236435" unit="keV" ucd="em.energy"/>
+            <Param name="Upper_Energy_Bound" value="264.7216" unit="keV" ucd="em.energy"/>
+            <Param name="Triggered_GRDs" value="011" ucd="instr.param"/>
+        </Group>
+        <Group name="Satellite_Info">
+            <Param name="Attitude_Ra" value="210.64" unit="deg" ucd="instr.param"/>
+            <Param name="Attitude_Dec" value="22.00" unit="deg" ucd="instr.param"/>
+            <Param name="Attitude_Roll" value="290.58" unit="deg" ucd="instr.param"/>
+        </Group>
+    </What>
+    <WhereWhen>
+        <ObsDataLocation>
+            <ObservatoryLocation id="GEOLEO"/>
+            <ObservationLocation>
+                <AstroCoordSystem id="UTC-ICRS-GEO"/>
+                <AstroCoords coord_system_id="UTC-ICRS-GEO">
+                    <Time unit="s">
+                        <TimeInstant>
+                            <ISOTime>2025-03-11T20:41:47</ISOTime>
+                        </TimeInstant>
+                    </Time>
+                </AstroCoords>
+            </ObservationLocation>
+        </ObsDataLocation>
+    </WhereWhen>
+    <Why importance="0.48">
+        <Inference probability="0.48">
+            <Concept>process.variation.burst;em.gamma</Concept>
+        </Inference>
+    </Why>
+    <How>
+        <Description>N1g notice, data from GRM</Description>
+        <Reference uri="https://www.svom.eu/en/grm-gamma-ray-burst-monitor-en/"/>
+    </How>
+</voe:VOEvent>

--- a/gtecs/alert/sentinel.py
+++ b/gtecs/alert/sentinel.py
@@ -251,6 +251,11 @@ class Sentinel:
             topics += [
                 'gcn.notices.einstein_probe.wxt.alert',
             ]
+            # SVOM notices
+            topics += [
+                'gcn.notices.svom.voevent.grm',
+                'gcn.notices.svom.voevent.eclairs',
+            ]
             # IceCube notices
             topics += [
                 'gcn.classic.voevent.ICECUBE_ASTROTRACK_BRONZE',

--- a/gtecs/alert/slack.py
+++ b/gtecs/alert/slack.py
@@ -63,12 +63,18 @@ def send_notice_report(notice, time=None):
 
     if notice.role != 'observation':
         msg += f'*NOTE: THIS IS A {notice.role.upper()} EVENT*\n'
+    msg += '\n'
 
     # Make sure we have the skymap downloaded
     notice.get_skymap()
 
-    # Get event-specific details from the notice class
-    msg += '\n'
+    # Basic event details (retractions don't have an event_time)
+    msg += f'Event: {notice.event_name}\n'
+    if notice.event_time is not None:
+        msg += f'Detection time: {notice.event_time.iso}'
+        msg += f' _({(time - notice.event_time).to(u.hour).value:.1f}h ago)_\n'
+
+    # Add event-specific details from the notice class
     msg += notice.slack_details
 
     # Get strategy details (a short version compared to the full notice)


### PR DESCRIPTION
This PR adds in a `SVOMNotice` class which allows handling ECLAIRs and GRM notices from SVOM (see #94). We've had this running for a little while now and it seems to be working well.

This also includes a small redo of the Slack alert message text (to get the time since event in the first notice) and a new example of a small EP alert which caused the error described in https://github.com/GOTO-OBS/goto-tile/issues/108 and fixed in https://github.com/GOTO-OBS/goto-tile/issues/109.

Closes #94 