### PR TITLE
Use Alembic for database management

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ You should then be able to import the module from within Python.
 
 Several scripts from the `scripts` folder should also be added to your path, in particular the `sentinel` script which will listen for live GCN alerts (see **Usage** below).
 
+### Setting up the database
+
+You'll need to make sure PostgreSQL is installed and configured before setting up the database. The config file contains parameters for the user and password to use when interacting with the database, make sure you create this user with rights first (e.g. `sudo -u postgres createuser -edP gtecs`) (a useful hint from https://stackoverflow.com/a/26735105:  edit `/etc/postgresql/12/main/pg_hba.conf` to change `local all all peer` to ` local all all md5` to remove the annoying user bits, then restart `sudo service postgresql restart`).
+
+Then you can create the database with `createdb -O gtecs gtecs`, or just log into PostgreSQL as the `gtecs` user and run `CREATE DATABASE gtecs;`.
+
+Database migrations are handled using Alembic, which should be installed as part of the package. To create the initial database schema, run:
+
+    alembic upgrade head
+
 ### Configuration
 
 The module will look for a file named `.alert.conf` either in the user's home directory, the `gtecs` subdirectory, or a path specified by the `GTECS_CONF` environment variable. An example file is included in the base directory of this repository.

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,129 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+# Use forward slashes (/) also on windows to provide an os agnostic path
+script_location = alembic
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.
+prepend_sys_path = .
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the python>=3.9 or backports.zoneinfo library and tzdata library.
+# Any required deps can installed by adding `alembic[tz]` to the pip requirements
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to alembic/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "version_path_separator" below.
+# version_locations = %(here)s/bar:%(here)s/bat:alembic/versions
+
+# version path separator; As mentioned above, this is the character used to split
+# version_locations. The default within new alembic.ini files is "os", which uses os.pathsep.
+# If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.
+# Valid values for version_path_separator are:
+#
+# version_path_separator = :
+# version_path_separator = ;
+# version_path_separator = space
+# version_path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+version_path_separator = os
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# database URL.  This is consumed by the user-maintained env.py script only.
+# other means of configuring database URLs may be customized within the env.py
+# file.
+# See notes in "escaping characters in ini files" for guidelines on
+# passwords
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the exec runner, execute a binary
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = %(here)s/.venv/bin/ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic,alembic_utils
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[logger_alembic_utils]
+level = INFO
+handlers =
+qualname = alembic_utils
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -8,7 +8,7 @@ from sqlalchemy import MetaData, create_engine
 
 from alembic import context
 from gtecs.alert import params
-from gtecs.alert.database import Base
+from gtecs.alert.database import Base, functions, triggers
 
 # This is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -18,6 +18,26 @@ if config.config_file_name is not None:
 
 # Get the table metadata from the Base, which includes all schemas
 target_metadata = Base.metadata
+
+# Automatically create and register alembic-utils entities for functions and triggers
+entities = []
+for func_info in functions.values():
+    pg_function = PGFunction(
+        schema=func_info["schema"],
+        signature=func_info["signature"],
+        definition=func_info["definition"],
+    )
+    entities.append(pg_function)
+for trigger_info in triggers.values():
+    pg_trigger = PGTrigger(
+        schema=trigger_info["schema"],
+        signature=trigger_info["signature"],
+        on_entity=trigger_info["on_entity"],
+        is_constraint=False,
+        definition=trigger_info["definition"],
+    )
+    entities.append(pg_trigger)
+register_entities(entities)
 
 
 def get_url() -> str:

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -16,12 +16,8 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# Filter Base.metadata to only include tables in the 'alert' schema
-metadata = MetaData(schema="alert")
-for table in Base.metadata.tables.values():
-    if table.schema == "alert":
-        table.tometadata(metadata)
-target_metadata = metadata
+# Get the table metadata from the Base, which includes all schemas
+target_metadata = Base.metadata
 
 
 def get_url() -> str:
@@ -34,10 +30,7 @@ def get_url() -> str:
 
 def include_name(name, type_, parent_names):
     """Include only specific object types in autogenerate."""
-    if type_ == "schema":
-        # Exclude other schemas
-        return name == "alert"
-    elif type_ == "grant_table":
+    if type_ == "grant_table":
         # Exclude tracking grants
         return False
     else:
@@ -46,8 +39,12 @@ def include_name(name, type_, parent_names):
 
 def include_object(object, name, type_, reflected, compare_to):
     """Include only specific objects in autogenerate."""
-    if hasattr(object, "schema") and object.schema != "alert":
-        # Only include objects in the alert schema
+    # Only generate migration operations for alert schema objects
+    if hasattr(object, "schema"):
+        if object.schema != "alert":
+            return False
+    # For reflected objects (from database), only include alert schema
+    if reflected and hasattr(object, "schema") and object.schema != "alert":
         return False
     return True
 

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,109 @@
+import re
+from logging.config import fileConfig
+
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+from alembic_utils.replaceable_entity import register_entities
+from sqlalchemy import MetaData, create_engine
+
+from alembic import context
+from gtecs.alert import params
+from gtecs.alert.database import Base
+
+# This is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Filter Base.metadata to only include tables in the 'alert' schema
+metadata = MetaData(schema="alert")
+for table in Base.metadata.tables.values():
+    if table.schema == "alert":
+        table.tometadata(metadata)
+target_metadata = metadata
+
+
+def get_url() -> str:
+    """Get the database URL from the package config."""
+    url = "postgresql://{}:{}@{}/gtecs".format(
+        params.DATABASE_USER, params.DATABASE_PASSWORD, params.DATABASE_HOST
+    )
+    return url
+
+
+def include_name(name, type_, parent_names):
+    """Include only specific object types in autogenerate."""
+    if type_ == "schema":
+        # Exclude other schemas
+        return name == "alert"
+    elif type_ == "grant_table":
+        # Exclude tracking grants
+        return False
+    else:
+        return True
+
+
+def include_object(object, name, type_, reflected, compare_to):
+    """Include only specific objects in autogenerate."""
+    if hasattr(object, "schema") and object.schema != "alert":
+        # Only include objects in the alert schema
+        return False
+    return True
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = get_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        include_schemas=True,
+        include_name=include_name,
+        include_object=include_object,
+        version_table="alembic_version_alert",  # Use separate version table for alert schema
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = create_engine(get_url())
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            include_schemas=True,
+            include_name=include_name,
+            include_object=include_object,
+            version_table="alembic_version_alert",  # Use separate version table for alert schema
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/3db278b3e383_add_timestamps.py
+++ b/alembic/versions/3db278b3e383_add_timestamps.py
@@ -1,0 +1,82 @@
+"""add_timestamps
+
+Revision ID: 3db278b3e383
+Revises: 5fe462464963
+Create Date: 2025-07-29 13:15:53.628525
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic_utils.pg_function import PGFunction
+from alembic_utils.pg_trigger import PGTrigger
+from sqlalchemy import text as sql_text
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "3db278b3e383"
+down_revision: Union[str, None] = "5fe462464963"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Att timestamp columns to existing tables
+    op.add_column(
+        "events",
+        sa.Column("ts", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        schema="alert",
+    )
+    op.add_column(
+        "notices",
+        sa.Column("ts", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        schema="alert",
+    )
+
+    # Create the update_ts function to set the timestamp
+    alert_update_ts = PGFunction(
+        schema="alert",
+        signature="update_ts()",
+        definition="RETURNS TRIGGER\nLANGUAGE plpgsql AS\n$function$\nBEGIN\n    NEW.ts := now();\n    RETURN NEW;\nEND\n$function$",
+    )
+    op.create_entity(alert_update_ts)
+
+    # Create triggers to call update_ts on update
+    for table in ["events", "notices"]:
+        update_ts_trigger = PGTrigger(
+            schema="alert",
+            signature=f"trig_update_ts_{table}",
+            on_entity=f"alert.{table}",
+            is_constraint=False,
+            definition=f"BEFORE UPDATE ON alert.{table} FOR EACH ROW EXECUTE FUNCTION alert.update_ts()",
+        )
+        op.create_entity(update_ts_trigger)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Drop the triggers and functions
+    for table in reversed(["events", "notices"]):
+        op.drop_entity(
+            PGTrigger(
+                schema="alert",
+                signature=f"trig_update_ts_{table}",
+                on_entity=f"alert.{table}",
+                is_constraint=False,
+                definition="",  # definition is not needed for drop
+            )
+        )
+    op.drop_entity(
+        PGFunction(
+            schema="alert",
+            signature="update_ts()",
+            definition="",  # definition is not needed for drop
+        )
+    )
+
+    # Drop the timestamp columns
+    op.drop_column("notices", "ts", schema="alert")
+    op.drop_column("events", "ts", schema="alert")

--- a/alembic/versions/5fe462464963_initial.py
+++ b/alembic/versions/5fe462464963_initial.py
@@ -1,0 +1,76 @@
+"""initial
+
+Revision ID: 5fe462464963
+Revises:
+Create Date: 2025-07-29 11:49:22.871886
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '5fe462464963'
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Create alert schema if it doesn't exist
+    op.execute("CREATE SCHEMA IF NOT EXISTS alert")
+
+    # Create tables
+    # Note the order of table creation is important due to foreign key constraints.
+
+    # Events table
+    op.create_table(
+        'events',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(length=255), nullable=False),
+        sa.Column('type', sa.String(length=255), nullable=False),
+        sa.Column('origin', sa.String(length=255), nullable=False),
+        sa.Column('time', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        schema='alert'
+    )
+    op.create_index(op.f('ix_alert_events_name'), 'events', ['name'], unique=True, schema='alert')
+    op.create_index(op.f('ix_alert_events_type'), 'events', ['type'], unique=False, schema='alert')
+
+    # Notices table
+    op.create_table(
+        'notices',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('ivorn', sa.String(length=255), nullable=False),
+        sa.Column('received', sa.DateTime(), nullable=False, server_default=sa.text('now()')),
+        sa.Column('payload', sa.LargeBinary(), nullable=False),
+        sa.Column('skymap', sa.LargeBinary(), nullable=True),
+        sa.Column('event_id', sa.Integer(), nullable=True),
+        sa.Column('survey_id', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(['event_id'], ['alert.events.id'], ),
+        sa.ForeignKeyConstraint(['survey_id'], ['obs.surveys.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('ivorn'),
+        schema='alert'
+    )
+    op.create_index(op.f('ix_alert_notices_received'), 'notices', ['received'], unique=False, schema='alert')
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Drop tables in reverse order of creation
+
+    # Notices table
+    op.drop_index(op.f('ix_alert_notices_received'), table_name='notices', schema='alert')
+    op.drop_table('notices', schema='alert')
+
+    # Events table
+    op.drop_index(op.f('ix_alert_events_type'), table_name='events', schema='alert')
+    op.drop_index(op.f('ix_alert_events_name'), table_name='events', schema='alert')
+    op.drop_table('events', schema='alert')
+
+    # Finally, drop the alert schema
+    op.execute("DROP SCHEMA IF EXISTS alert CASCADE")

--- a/gtecs/alert/database.py
+++ b/gtecs/alert/database.py
@@ -125,6 +125,9 @@ class Event(Base):
     origin = Column(String(255), nullable=False)
     time = Column(DateTime, nullable=True, default=None)
 
+    # Update timestamp
+    ts = Column(DateTime, nullable=False, server_default=func.now())
+
     # Foreign relationships
     notices = relationship(
         'Notice',
@@ -231,6 +234,9 @@ class Notice(Base):
     event_id = Column(Integer, ForeignKey(f'{SCHEMA}.events.id'), nullable=True)
     survey_id = Column(Integer, ForeignKey('obs.surveys.id'), nullable=True)
 
+    # Update timestamp
+    ts = Column(DateTime, nullable=False, server_default=func.now())
+
     # Foreign relationships
     event = relationship(
         'Event',
@@ -325,3 +331,41 @@ class Notice(Base):
             # Decode the bytes
             notice.skymap = SkyMap.from_fits(self.skymap)
         return notice
+
+
+# Registries for other entities
+# Note: These are created in the database via alembic-utils
+functions = {}
+triggers = {}
+
+# Define ts update function and triggers for tracking changes
+ts_function = 'update_ts()'
+ts_function_sql = """RETURNS TRIGGER
+LANGUAGE plpgsql AS
+$function$
+BEGIN
+    NEW.ts := now();
+    RETURN NEW;
+END
+$function$;
+"""
+functions[ts_function] = {
+    'schema': SCHEMA,
+    'signature': ts_function,
+    'definition': ts_function_sql,
+}
+tables_with_ts = [
+    table for table in Base.metadata.tables.values()
+    if table.schema == SCHEMA and 'ts' in table.columns
+]
+for table in tables_with_ts:
+    ts_trigger = f'trig_update_ts_{table.name}'
+    ts_trigger_sql = f"""BEFORE UPDATE ON {SCHEMA}.{table.name}
+    FOR EACH ROW EXECUTE FUNCTION {SCHEMA}.update_ts();
+    """
+    triggers[ts_trigger] = {
+        'schema': SCHEMA,
+        'signature': ts_trigger,
+        'on_entity': f"{SCHEMA}.{table.name}",
+        'definition': ts_trigger_sql,
+    }

--- a/gtecs/alert/database.py
+++ b/gtecs/alert/database.py
@@ -19,6 +19,16 @@ from . import params
 from .notices import Notice as EventNotice
 
 
+__all__ = [
+    'get_session',
+    'session_manager',
+    'Event',
+    'Notice',
+]
+
+SCHEMA = 'alert'
+
+
 def get_session(user=None, password=None, host=None, echo=None, pool_pre_ping=None):
     """Create a database connection session.
 
@@ -104,7 +114,7 @@ class Event(Base):
 
     # Set corresponding SQL table name
     __tablename__ = 'events'
-    __table_args__ = {'schema': 'alert'}
+    __table_args__ = {'schema': SCHEMA}
 
     # Primary key
     db_id = Column('id', Integer, primary_key=True)
@@ -126,7 +136,7 @@ class Event(Base):
     surveys = relationship(
         'Survey',
         order_by='Survey.db_id',
-        secondary='alert.notices',
+        secondary=f'{SCHEMA}.notices',
         primaryjoin='Notice.event_id == Event.db_id',
         secondaryjoin='Survey.db_id == Notice.survey_id',
         backref=backref(  # NB Use legacy backref to add corresponding relationship to Surveys
@@ -206,7 +216,7 @@ class Notice(Base):
 
     # Set corresponding SQL table name
     __tablename__ = 'notices'
-    __table_args__ = {'schema': 'alert'}
+    __table_args__ = {'schema': SCHEMA}
 
     # Primary key
     db_id = Column('id', Integer, primary_key=True)
@@ -218,7 +228,7 @@ class Notice(Base):
     skymap = Column(LargeBinary, nullable=True)
 
     # Foreign keys
-    event_id = Column(Integer, ForeignKey('alert.events.id'), nullable=True)
+    event_id = Column(Integer, ForeignKey(f'{SCHEMA}.events.id'), nullable=True)
     survey_id = Column(Integer, ForeignKey('obs.surveys.id'), nullable=True)
 
     # Foreign relationships

--- a/scripts/setup_alertdb
+++ b/scripts/setup_alertdb
@@ -1,50 +1,236 @@
 #!/usr/bin/env python3
-"""Create a blank alert database."""
+"""Prepare a blank alert database."""
 
 import argparse
 import sys
 
+from sqlalchemy import text
+
+from gtecs.alert import database as db
 from gtecs.alert import params
 from gtecs.alert.database import Base
 from gtecs.common.database import create_database
 
 
+def check_database_connection():
+    """Check if we can connect to the database."""
+    try:
+        with db.session_manager() as session:
+            # Simple query to test database connection
+            session.execute(text("SELECT 1")).fetchone()
+            return True
+    except Exception:
+        raise
+        return False
+
+
+def check_schema_exists(schema_name):
+    """Check if the specified schema exists within the database."""
+    try:
+        with db.session_manager() as session:
+            # Try to query the information schema to see if our schema exists
+            result = session.execute(
+                text(
+                    f"SELECT schema_name FROM information_schema.schemata WHERE schema_name = '{schema_name}'"
+                )
+            ).fetchone()
+            return result is not None
+    except Exception:
+        return False
+
+
+def check_tables_exist(schema_name, base):
+    """Check if all expected tables exist in the specified schema."""
+    # Get expected table names from SQLAlchemy metadata
+    expected_tables = {
+        table.name
+        for table in base.metadata.tables.values()
+        if table.schema == schema_name
+    }
+
+    try:
+        with db.session_manager() as session:
+            # Query for all tables in the specified schema
+            result = session.execute(
+                text(
+                    f"SELECT table_name FROM information_schema.tables "
+                    f"WHERE table_schema = '{schema_name}' AND table_type = 'BASE TABLE'"
+                )
+            ).fetchall()
+
+            existing_tables = {row[0] for row in result}
+            missing_tables = expected_tables - existing_tables
+
+            return len(missing_tables) == 0, missing_tables
+    except Exception:
+        return False, expected_tables
+
+
+def check_database_empty(schema_name, base):
+    """Check if the database is empty (no data in any tables in the specified schema)."""
+    try:
+        with db.session_manager() as session:
+            # Check all tables for any data
+            for table in base.metadata.tables.values():
+                if table.schema == schema_name:
+                    result = session.execute(
+                        text(f"SELECT COUNT(*) FROM {schema_name}.{table.name}")
+                    ).scalar()
+                    if result > 0:
+                        return False
+            return True
+    except Exception:
+        return False
+
+
+def clear_database(schema_name, base, verbose=False):
+    """Clear all data from tables in the specified schema while preserving structure."""
+    # Get table names from metadata in reverse dependency order
+    # We need to delete in reverse order to avoid foreign key constraint issues
+    table_names = [
+        table.name
+        for table in reversed(base.metadata.sorted_tables)
+        if table.schema == schema_name
+    ]
+
+    try:
+        with db.session_manager() as session:
+            # Delete from tables in dependency order
+            for table_name in table_names:
+                result = session.execute(text(f"DELETE FROM {schema_name}.{table_name}"))
+                if result.rowcount > 0 and verbose:
+                    print(f"  Cleared {result.rowcount} rows from {table_name}")
+            session.commit()
+    except Exception as e:
+        session.rollback()
+
+        # Check if it's a foreign key violation
+        import psycopg2.errors
+        if isinstance(e.orig if hasattr(e, 'orig') else e, psycopg2.errors.ForeignKeyViolation):
+            error_msg = str(e)
+
+            # Extract both table names from the error message
+            referenced_table = None
+            referencing_table = None
+
+            if 'table "' in error_msg:
+                # Extract the referenced table (the one being deleted from)
+                start = error_msg.find('table "') + 7
+                end = error_msg.find('"', start)
+                referenced_table = error_msg[start:end]
+
+                # Extract the referencing table (the one with the foreign key)
+                if ' on table "' in error_msg:
+                    start = error_msg.find('" on table "') + 12
+                    end = error_msg.find('"', start)
+                    referencing_table = error_msg[start:end]
+
+            if referenced_table and referencing_table:
+                # Find schemas for both tables from metadata
+                referenced_schema = schema_name  # default to current schema
+                referencing_schema = 'public'   # default to public schema
+
+                for table in base.metadata.tables.values():
+                    if table.name == referenced_table:
+                        referenced_schema = table.schema or 'public'
+                    if table.name == referencing_table:
+                        referencing_schema = table.schema or 'public'
+
+                print(f"  ERROR clearing rows from {table_name} - foreign key violation.")
+                print(f"    Table {referencing_schema}.{referencing_table} has a foreign", end=' ')
+                print(f"key referencing {referenced_schema}.{referenced_table}.")
+                print(f"    Please clear the {referencing_schema} schema first.")
+            else:
+                print(f"ERROR: Foreign key violation: {error_msg}")
+        else:
+            print(f"ERROR: Failed to clear database: {e}")
+
+        sys.exit(1)
+
+
 def run(overwrite=False, verbose=False):
     """Create and fill the database."""
-    # Create a blank database
-    print('Creating blank database...')
-    try:
-        create_database(
-            Base,
-            name='alert',
-            description='Sentinel alert database',
-            user=params.DATABASE_USER,
-            password=params.DATABASE_PASSWORD,
-            host=params.DATABASE_HOST,
-            overwrite=overwrite,
-            verbose=verbose,
+
+    # Check if we can connect to the gtecs database
+    if not check_database_connection():
+        print('ERROR: Cannot connect to the "gtecs" database.')
+        print(
+            "       Please check your database configuration and ensure PostgreSQL is running."
         )
-    except ValueError as err:
-        if 'already exists' in str(err):
-            print('ERROR: Database already exists.')
-            print('       Rerun with -o/--overwrite to drop existing data.')
-            sys.exit()
+        print('       You may need to create the "gtecs" database first.')
+        sys.exit(1)
+
+    if verbose:
+        print('Successfully connected to "gtecs" database.')
+
+    # Check if the alert schema exists
+    if not check_schema_exists(schema_name="alert"):
+        print('ERROR: Schema "alert" does not exist in the gtecs database.')
+        print(
+            '       Please run "alembic upgrade head" to create the schema and tables.'
+        )
+        sys.exit(1)
+
+    if verbose:
+        print('Found existing schema "alert" in gtecs database.')
+
+    # Check if all expected tables exist
+    tables_exist, missing_tables = check_tables_exist(schema_name="alert", base=Base)
+    if not tables_exist:
+        print("ERROR: Schema exists but some tables are missing:")
+        for table in sorted(missing_tables):
+            print(f"       - {table}")
+        print('       Please run "alembic upgrade head" to create all required tables.')
+        sys.exit(1)
+
+    if verbose:
+        print("All expected tables found in database.")
+
+    # Check if the database is empty
+    is_empty = check_database_empty(schema_name="alert", base=Base)
+
+    if not is_empty:
+        if not overwrite:
+            print("ERROR: Database contains data.")
+            print("       Use -o/--overwrite to clear existing data.")
+            sys.exit(1)
         else:
-            raise
+            try:
+                print("Clearing existing data from database...")
+                clear_database(schema_name="alert", base=Base, verbose=verbose)
+                print("Database cleared successfully.")
+            except Exception as e:
+                print("ERROR: Failed to clear database.")
+                print(f"       {e}")
+                sys.exit(1)
+    else:
+        print("Database is empty.")
 
-    print('Done')
 
+if __name__ == "__main__":
+    description = """Setup the sentinel alert database.
 
-if __name__ == '__main__':
-    description = """Create the sentinel alert database."""
+    The database schema must already exist (created via alembic).
+    """
 
-    parser = argparse.ArgumentParser(description=description,
-                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=description, formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
 
-    parser.add_argument('-v', '--verbose', action='store_true', default=False,
-                        help='Print SQL statements?')
-    parser.add_argument('-o', '--overwrite', action='store_true', default=False,
-                        help='Overwrite an existing database [WARNING: WILL LOSE DATA]?')
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        default=False,
+        help="Print verbose output",
+    )
+    parser.add_argument(
+        "-o",
+        "--overwrite",
+        action="store_true",
+        default=False,
+        help="Clear existing data [WARNING: WILL LOSE DATA]",
+    )
 
     args = parser.parse_args()
 

--- a/scripts/setup_alertdb
+++ b/scripts/setup_alertdb
@@ -2,6 +2,7 @@
 """Prepare a blank alert database."""
 
 import argparse
+import getpass
 import sys
 
 from sqlalchemy import text
@@ -193,6 +194,10 @@ def run(overwrite=False, verbose=False):
         if not overwrite:
             print("ERROR: Database contains data.")
             print("       Use -o/--overwrite to clear existing data.")
+            sys.exit(1)
+        elif getpass.getuser() == 'goto':
+            print("ERROR: Attempting to clear GOTO database.")
+            print("       This is not allowed for safety reasons.")
             sys.exit(1)
         else:
             try:

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,10 @@ REQUIRES = ['numpy',
             'pandas',
             'requests',
             'setuptools',
+            'sqlalchemy>=2',
+            'psycopg2',
+            'alembic',
+            'alembic-utils',
             ]
 
 setup(name='gtecs-alert',


### PR DESCRIPTION
This PR adds in support for database migration using SQLAlchemy's [alembic](https://alembic.sqlalchemy.org/en/latest/). In short this should make doing updates to the databases a lot easier, as I can make changes to the ORM and then generate migration scripts using alembic that will make the changes to the actual database.

The `alembic-utils` package is also used to handle things like functions and triggers.

As a nice test case, the AlertDB didn't include an auto-updating timestamp column like all the tables in the ObsDB. So This PR adds that through an alembic patch which can be applied simply to the existing database.

The `setup_obsdb`/`setup_alertdb` scripts have been changed, since it wouldn't actually be used to set up a blank database any more. In practice I just used them to refresh my test database nice and easily, as well as add default GOTO entries for the ObsDB. So now that's all they do, with a slight catch that you'd have to clear the alert_db first if there are any entries in it to avoid foreign key issues.

This PR is has a mirror in https://github.com/GOTO-OBS/gtecs-obs/pull/102, as well as some updates in https://github.com/GOTO-OBS/gtecs-common/pull/12 which includes removing leftover MySQL support.