### PR TITLE
Add Coincidence detection for overlapping GRB alerts

### DIFF
--- a/alembic/versions/f30c625ee0b7_coincidence.py
+++ b/alembic/versions/f30c625ee0b7_coincidence.py
@@ -1,0 +1,102 @@
+"""coincidence
+
+Revision ID: f30c625ee0b7
+Revises: 3db278b3e383
+Create Date: 2025-08-01 11:15:23.432892
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic_utils.pg_trigger import PGTrigger
+from sqlalchemy import text as sql_text
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f30c625ee0b7"
+down_revision: Union[str, None] = "3db278b3e383"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Create Coincidences table
+    op.create_table(
+        "coincidences",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("ts", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        schema="alert",
+    )
+
+    # Add trigger to update 'ts' column on Coincidences table
+    #
+    # NB: This is taken from a separate migration to avoid circular dependencies when creating the
+    # Coincidences table:
+    #  1) Alembic detects the new table needs to be created
+    #  2) alembic-utils tries to simulate the trigger creation to see if it needs updating
+    #  3) The trigger references alert.coincidences which doesn't exist yet
+    #  4) The simulation fails
+    #
+    # To get the autogenerate to work, I excluded the coincidences table from the triggers
+    # in database.py:
+    # ```
+    # if table.schema == SCHEMA and 'ts' in table.columns and table.name != 'coincidences'
+    # ```
+    # then:
+    #   upgrade the database (alembic upgrade head)
+    #   run autogenerate again to create this code
+    #   copy it into this migration (commented out) and delete the second migration file
+    #   downgrade the database (alembic downgrade -1)
+    #   uncomment the code
+    #   finally run the upgrade again (alembic upgrade head)
+    update_ts_trigger = PGTrigger(
+        schema="alert",
+        signature="trig_update_ts_coincidences",
+        on_entity="alert.coincidences",
+        is_constraint=False,
+        definition="BEFORE UPDATE ON alert.coincidences\n    FOR EACH ROW EXECUTE FUNCTION alert.update_ts()",
+    )
+    op.create_entity(update_ts_trigger)
+
+    # Add foreign key to Events table
+    op.add_column(
+        "events",
+        sa.Column("coincidence_id", sa.Integer(), nullable=True),
+        schema="alert",
+    )
+    op.create_foreign_key(
+        "events_coincidence_id_fkey",
+        "events",
+        "coincidences",
+        ["coincidence_id"],
+        ["id"],
+        source_schema="alert",
+        referent_schema="alert",
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Remove foreign key from Events table
+    op.drop_constraint(
+        "events_coincidence_id_fkey", "events", schema="alert", type_="foreignkey"
+    )
+    op.drop_column("events", "coincidence_id", schema="alert")
+
+    # Drop the trigger
+    op.drop_entity(
+        PGTrigger(
+            schema="alert",
+            signature="trig_update_ts_coincidences",
+            on_entity="alert.coincidences",
+            is_constraint=False,
+            definition="",  # definition is not needed for drop
+        )
+    )
+
+    # Drop Coincidences table
+    op.drop_table("coincidences", schema="alert")

--- a/gtecs/alert/coincidence.py
+++ b/gtecs/alert/coincidence.py
@@ -94,9 +94,11 @@ def find_coincident_events(
     """
     with alert_db.session_manager() as session:
         # Get any Events from the database that have a matching event time
+        start_time = notice.event_time - time_window * u.second
+        end_time = notice.event_time + time_window * u.second
         query = session.query(alert_db.Event)
-        query = query.filter(alert_db.Event.time >= notice.event_time - time_window * u.second)
-        query = query.filter(alert_db.Event.time <= notice.event_time + time_window * u.second)
+        query = query.filter(alert_db.Event.time >= start_time.datetime)
+        query = query.filter(alert_db.Event.time <= end_time.datetime)
         query = query.filter(alert_db.Event.name != notice.event_name) # Don't include this event!
         if type_limit:
             query = query.filter(alert_db.Event.type == notice.event_type)

--- a/gtecs/alert/coincidence.py
+++ b/gtecs/alert/coincidence.py
@@ -1,0 +1,141 @@
+"""Functions for detecting coincident events."""
+
+from astropy import units as u
+
+import numpy as np
+
+from . import database as alert_db
+
+def get_skymap_overlap(skymap1, skymap2, contour=0.95, regrade_nside=128):
+    """Get the overlap fraction between two skymaps at a given contour level.
+
+    TODO: This could be a method on the gototile.SkyMap class
+    """
+    # Regrade each skymap to the same nside
+    # TODO: It would be nice if it returned a new skymap (with inplace=False)
+    #       instead of modifying the original one.
+    if skymap1.nside != regrade_nside:
+        skymap1 = skymap1.copy()
+        skymap1.regrade(nside=regrade_nside)
+    if skymap2.nside != regrade_nside:
+        skymap2 = skymap2.copy()
+        skymap2.regrade(nside=regrade_nside)
+
+    # Get the pixel indices within the contour level
+    contour_ipix1 = set(np.where(skymap1.contours<contour)[0])
+    contour_ipix2 = set(np.where(skymap2.contours<contour)[0])
+    intersection = contour_ipix1.intersection(contour_ipix2)
+    if len(intersection) == 0:
+        return 0.0
+
+    # We want to return the biggest overlap fraction
+    # (i.e. the fraction of the smaller skymap that overlaps with the larger one)
+    return len(intersection) / min(len(contour_ipix1), len(contour_ipix2))
+
+
+def get_tile_overlap(notice1, notice2):
+    """Get the overlap fraction between two notice tilesets.
+
+    Returns the fraction of the smaller set that overlaps with the larger one.
+    """
+    selected1 = notice1.select_tiles()
+    selected2 = notice2.select_tiles()
+    tile_set1 = set(selected1['tilename'])
+    tile_set2 = set(selected2['tilename'])
+    intersection = tile_set1.intersection(tile_set2)
+    if len(intersection) == 0:
+        return 0.0
+
+    # We want to return the biggest overlap fraction
+    # (i.e. the fraction of the smaller set that overlaps with the larger one)
+    return len(intersection) / min(len(tile_set1), len(tile_set2))
+
+
+def find_coincident_events(
+        notice,
+        time_window=10,
+        skymap_contour=0.95,
+        type_limit=True,
+        return_parameters=False
+    ):
+    """Check the AlertDB for any other events with matching times and positions.
+
+    Parameters
+    ----------
+    notice : `gtecs.alert.notices.Notice`
+        The notice to check for coincidences with.
+
+    time_window : float, optional
+        The time window (in seconds) from the event time to check for coincidences.
+        Default is 10 seconds.
+    skymap_contour : float, optional
+        The contour level to use for the skymap overlap check.
+        Default is 0.95 (i.e. the 95% contour level).
+    type_limit : bool, optional
+        If True, only check for events of the same type as the given notice.
+        Default is True.
+    return_parameters : bool, optional
+        If True, return the time difference, skymap overlap, and tile overlap
+        for each matching event.
+        Default is False.
+        If False, only return the matching event IDs.
+
+    Returns
+    -------
+    matching_events : list of int or list of tuples
+        If `return_parameters` is False, a list of database IDs for any matching events.
+        If `return_parameters` is True, a list of tuples containing the database ID,
+        time difference, skymap overlap, and tile overlap for each matching event.
+        Each tuple is of the form (db_id, time_diff, skymap_overlap, tile_overlap).
+        The time difference is in seconds, and the skymap and tile overlaps are fractions
+        between 0 and 1.
+        If no matches are found, an empty list is returned.
+
+    """
+    with alert_db.session_manager() as session:
+        # Get any Events from the database that have a matching event time
+        query = session.query(alert_db.Event)
+        query = query.filter(alert_db.Event.time >= notice.event_time - time_window * u.second)
+        query = query.filter(alert_db.Event.time <= notice.event_time + time_window * u.second)
+        query = query.filter(alert_db.Event.name != notice.event_name) # Don't include this event!
+        if type_limit:
+            query = query.filter(alert_db.Event.type == notice.event_type)
+        db_events = query.all()
+
+        # Nothing within the time window
+        if len(db_events) == 0:
+            return []
+
+        # We found some, but we want to check if any of them overlap with this notice's skymap
+        # We want to check both the notice skymaps and the selected tiles,
+        # as either overlapping should trigger a match.
+        matching_events = []
+        for db_event in db_events:
+            # We only care about the latest notice for each event,
+            # any previous ones should have already been deleted.
+            event_notice = db_event.notices[-1].gcn
+            time_diff = (event_notice.event_time - notice.event_time).value
+
+            # Check if either of the notice skymaps or tilesets overlap
+            skymap_overlap = get_skymap_overlap(
+                notice.skymap, event_notice.skymap, contour=skymap_contour
+            )
+            tile_overlap = get_tile_overlap(notice, event_notice)
+            if tile_overlap == 0 and skymap_overlap == 0:
+                # Neither overlap, so the time must have been a coincidence
+                continue
+
+            # We have a match!
+            if return_parameters:
+                params = (
+                    db_event.db_id,
+                    time_diff,
+                    skymap_overlap,
+                    tile_overlap
+                )
+                matching_events.append(params)
+            else:
+                # Just append the event ID
+                matching_events.append(db_event.db_id)
+
+    return matching_events

--- a/gtecs/alert/coincidence.py
+++ b/gtecs/alert/coincidence.py
@@ -82,7 +82,7 @@ def find_coincident_events(
 
     Returns
     -------
-    matching_events : list of int or list of tuples
+    matched_event_ids : list of int or list of tuples
         If `return_parameters` is False, a list of database IDs for any matching events.
         If `return_parameters` is True, a list of tuples containing the database ID,
         time difference, skymap overlap, and tile overlap for each matching event.
@@ -100,27 +100,28 @@ def find_coincident_events(
         query = query.filter(alert_db.Event.name != notice.event_name) # Don't include this event!
         if type_limit:
             query = query.filter(alert_db.Event.type == notice.event_type)
-        db_events = query.all()
+        query = query.order_by(alert_db.Event.time)
+        matched_events = query.all()
 
         # Nothing within the time window
-        if len(db_events) == 0:
+        if len(matched_events) == 0:
             return []
 
         # We found some, but we want to check if any of them overlap with this notice's skymap
         # We want to check both the notice skymaps and the selected tiles,
         # as either overlapping should trigger a match.
-        matching_events = []
-        for db_event in db_events:
+        matched_event_ids = []
+        for matched_event in matched_events:
             # We only care about the latest notice for each event,
             # any previous ones should have already been deleted.
-            event_notice = db_event.notices[-1].gcn
-            time_diff = (event_notice.event_time - notice.event_time).value
+            matched_notice = matched_event.notices[-1].gcn
+            time_diff = (notice.event_time - matched_notice.event_time).to(u.second).value
 
             # Check if either of the notice skymaps or tilesets overlap
             skymap_overlap = get_skymap_overlap(
-                notice.skymap, event_notice.skymap, contour=skymap_contour
+                notice.skymap, matched_notice.skymap, contour=skymap_contour
             )
-            tile_overlap = get_tile_overlap(notice, event_notice)
+            tile_overlap = get_tile_overlap(notice, matched_notice)
             if tile_overlap == 0 and skymap_overlap == 0:
                 # Neither overlap, so the time must have been a coincidence
                 continue
@@ -128,14 +129,14 @@ def find_coincident_events(
             # We have a match!
             if return_parameters:
                 params = (
-                    db_event.db_id,
+                    matched_event.db_id,
                     time_diff,
                     skymap_overlap,
                     tile_overlap
                 )
-                matching_events.append(params)
+                matched_event_ids.append(params)
             else:
                 # Just append the event ID
-                matching_events.append(db_event.db_id)
+                matched_event_ids.append(matched_event.db_id)
 
-    return matching_events
+    return matched_event_ids

--- a/gtecs/alert/data/configspec.ini
+++ b/gtecs/alert/data/configspec.ini
@@ -14,7 +14,8 @@ KAFKA_BROKER = string(default='SCIMMA')
 KAFKA_GROUP_ID = string(default='gtecs_alert')
 KAFKA_BACKDATE = integer(default=1)
 
-# Filter parameters
+# Alert handling parameters
+COINCIDENT_TIME_WINDOW = integer(default=10)
 PROCESS_TEST_NOTICES = integer(default=0)
 
 # Database parameters

--- a/gtecs/alert/data/test_notices/Fermi/730284696-GBM_FIN_POS-GRB_240222A.json
+++ b/gtecs/alert/data/test_notices/Fermi/730284696-GBM_FIN_POS-GRB_240222A.json
@@ -1,0 +1,315 @@
+{
+    "ivorn": "ivo://nasa.gsfc.gcn/Fermi#GBM_Fin_Pos2024-02-22T08:51:31.47_730284696_0-924",
+    "role": "observation",
+    "version": "2.0",
+    "Who": {
+        "AuthorIVORN": "ivo://nasa.gsfc.tan/gcn",
+        "Author": {
+            "shortName": "Fermi (via VO-GCN)",
+            "contactName": "Julie McEnery",
+            "contactPhone": "+1-301-286-1632",
+            "contactEmail": "Julie.E.McEnery@nasa.gov"
+        },
+        "Date": "2024-02-22T09:00:56",
+        "Description": "This VOEvent message was created with GCN VOE version: 15.08 17jun22"
+    },
+    "What": {
+        "Param": [
+            {
+                "name": "Packet_Type",
+                "value": "115"
+            },
+            {
+                "name": "Pkt_Ser_Num",
+                "value": "8"
+            },
+            {
+                "name": "TrigID",
+                "value": "730284696",
+                "ucd": "meta.id"
+            },
+            {
+                "name": "Sequence_Num",
+                "value": "0",
+                "ucd": "meta.id.part"
+            },
+            {
+                "name": "Burst_TJD",
+                "value": "20362",
+                "unit": "days",
+                "ucd": "time"
+            },
+            {
+                "name": "Burst_SOD",
+                "value": "31891.47",
+                "unit": "sec",
+                "ucd": "time"
+            },
+            {
+                "name": "Burst_Inten",
+                "value": "0",
+                "unit": "cts",
+                "ucd": "phot.count"
+            },
+            {
+                "name": "Data_Integ",
+                "value": "0.000",
+                "unit": "sec",
+                "ucd": "time.interval"
+            },
+            {
+                "name": "Burst_Signif",
+                "value": "0.00",
+                "unit": "sigma",
+                "ucd": "stat.snr"
+            },
+            {
+                "name": "Phi",
+                "value": "109.00",
+                "unit": "deg",
+                "ucd": "pos.az.azi"
+            },
+            {
+                "name": "Theta",
+                "value": "109.00",
+                "unit": "deg",
+                "ucd": "pos.az.zd"
+            },
+            {
+                "name": "Algorithm",
+                "value": "41731",
+                "unit": "dn"
+            },
+            {
+                "name": "Lo_Energy",
+                "value": "44032",
+                "unit": "keV"
+            },
+            {
+                "name": "Hi_Energy",
+                "value": "279965",
+                "unit": "keV"
+            },
+            {
+                "name": "Trigger_ID",
+                "value": "0x20000000"
+            },
+            {
+                "name": "Misc_flags",
+                "value": "0x40000000"
+            },
+            {
+                "name": "LightCurve_URL",
+                "value": "http://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/triggers/2024/bn240222369/quicklook/glg_lc_medres34_bn240222369.gif",
+                "ucd": "meta.ref.url"
+            },
+            {
+                "name": "LocationMap_URL",
+                "value": "http://heasarc.gsfc.nasa.gov/FTP/fermi/data/gbm/triggers/2024/bn240222369/quicklook/glg_locplot_all_bn240222369.png",
+                "ucd": "meta.ref.url"
+            },
+            {
+                "name": "Coords_Type",
+                "value": "1",
+                "unit": "dn"
+            },
+            {
+                "name": "Coords_String",
+                "value": "source_object"
+            }
+        ],
+        "Group": [
+            {
+                "name": "Trigger_ID",
+                "Param": [
+                    {
+                        "name": "Def_NOT_a_GRB",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Target_in_Blk_Catalog",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Human_generated",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Robo_generated",
+                        "value": "true"
+                    },
+                    {
+                        "name": "Long_short",
+                        "value": "unknown"
+                    },
+                    {
+                        "name": "Spatial_Prox_Match",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Temporal_Prox_Match",
+                        "value": "true"
+                    },
+                    {
+                        "name": "Test_Submission",
+                        "value": "false"
+                    }
+                ]
+            },
+            {
+                "name": "Misc_Flags",
+                "Param": [
+                    {
+                        "name": "Values_Out_of_Range",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Flt_Generated",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Gnd_Generated",
+                        "value": "true"
+                    },
+                    {
+                        "name": "CRC_Error",
+                        "value": "false"
+                    }
+                ]
+            },
+            {
+                "name": "Obs_Support_Info",
+                "Description": "The Sun and Moon values are valid at the time the VOEvent XML message was created.",
+                "Param": [
+                    {
+                        "name": "Sun_RA",
+                        "value": "335.16",
+                        "unit": "deg",
+                        "ucd": "pos.eq.ra"
+                    },
+                    {
+                        "name": "Sun_Dec",
+                        "value": "-10.32",
+                        "unit": "deg",
+                        "ucd": "pos.eq.dec"
+                    },
+                    {
+                        "name": "Sun_Distance",
+                        "value": "108.58",
+                        "unit": "deg",
+                        "ucd": "pos.angDistance"
+                    },
+                    {
+                        "name": "Sun_Hr_Angle",
+                        "value": "-11.22",
+                        "unit": "hr"
+                    },
+                    {
+                        "name": "Moon_RA",
+                        "value": "133.41",
+                        "unit": "deg",
+                        "ucd": "pos.eq.ra"
+                    },
+                    {
+                        "name": "Moon_Dec",
+                        "value": "22.38",
+                        "unit": "deg",
+                        "ucd": "pos.eq.dec"
+                    },
+                    {
+                        "name": "MOON_Distance",
+                        "value": "83.27",
+                        "unit": "deg",
+                        "ucd": "pos.angDistance"
+                    },
+                    {
+                        "name": "Moon_Illum",
+                        "value": "95.81",
+                        "unit": "%",
+                        "ucd": "arith.ratio"
+                    },
+                    {
+                        "name": "Galactic_Long",
+                        "value": "280.68",
+                        "unit": "deg",
+                        "ucd": "pos.galactic.lon"
+                    },
+                    {
+                        "name": "Galactic_Lat",
+                        "value": "-6.39",
+                        "unit": "deg",
+                        "ucd": "pos.galactic.lat"
+                    },
+                    {
+                        "name": "Ecliptic_Long",
+                        "value": "190.66",
+                        "unit": "deg",
+                        "ucd": "pos.ecliptic.lon"
+                    },
+                    {
+                        "name": "Ecliptic_Lat",
+                        "value": "-66.23",
+                        "unit": "deg",
+                        "ucd": "pos.ecliptic.lat"
+                    }
+                ]
+            }
+        ],
+        "Description": "The Fermi-GBM location of a transient."
+    },
+    "WhereWhen": {
+        "ObsDataLocation": {
+            "ObservatoryLocation": {
+                "id": "GEOLUN"
+            },
+            "ObservationLocation": {
+                "AstroCoordSystem": {
+                    "id": "UTC-FK5-GEO"
+                },
+                "AstroCoords": {
+                    "coord_system_id": "UTC-FK5-GEO",
+                    "Time": {
+                        "unit": "s",
+                        "TimeInstant": {
+                            "ISOTime": "2024-02-22T08:51:31.47"
+                        }
+                    },
+                    "Position2D": {
+                        "unit": "deg",
+                        "Name1": "RA",
+                        "Name2": "Dec",
+                        "Value2": {
+                            "C1": "143.2600",
+                            "C2": "-60.3800"
+                        },
+                        "Error2Radius": "9.0700"
+                    }
+                }
+            }
+        },
+        "Description": "The RA,Dec coordinates are of the type: source_object."
+    },
+    "How": {
+        "Description": "Fermi Satellite, GBM Instrument",
+        "Reference": {
+            "uri": "http://gcn.gsfc.nasa.gov/fermi.html",
+            "type": "url"
+        }
+    },
+    "Why": {
+        "importance": "0.95",
+        "Inference": {
+            "probability": "1.0",
+            "Concept": "process.variation.burst;em.gamma"
+        }
+    },
+    "Citations": {
+        "EventIVORN": {
+            "cite": "followup",
+            "#text": "ivo://nasa.gsfc.gcn/Fermi#GBM_Alert_2024-02-22T08:51:31.47_730284696_1-866"
+        },
+        "Description": "This is an updated position to the original trigger."
+    },
+    "Description": null,
+    "Reference": {}
+}

--- a/gtecs/alert/data/test_notices/GECAM/297-FLT-GRB_240222A.json
+++ b/gtecs/alert/data/test_notices/GECAM/297-FLT-GRB_240222A.json
@@ -1,0 +1,150 @@
+{
+    "ivorn": "ivo://nasa.gsfc.gcn/GECAM#GND_Event_2024-02-22T885:53:14.88_000001-989",
+    "role": "observation",
+    "version": "2.0",
+    "Who": {
+        "AuthorIVORN": "ivo://nasa.gsfc.tan/gcn",
+        "Author": {
+            "shortName": "GECAM (via VO-GCN/TAN)",
+            "contactName": "Yue Huang",
+            "contactEmail": "huangyue@ihep.ac.cn"
+        },
+        "Date": "2024-02-22T09:10:38",
+        "Description": "This VOEvent message was created with GCN/TAN VOE version: 15.08 17jun22"
+    },
+    "What": {
+        "Param": [
+            {
+                "name": "Packet_Type",
+                "dataType": "int",
+                "value": "189"
+            },
+            {
+                "name": "Pkt_Ser_Num",
+                "dataType": "int",
+                "value": "1"
+            },
+            {
+                "name": "Trigger_Number",
+                "dataType": "int",
+                "value": "297",
+                "ucd": "meta.id"
+            },
+            {
+                "name": "MISSION",
+                "dataType": "string",
+                "value": "B",
+                "Description": "Which Mission."
+            },
+            {
+                "name": "EVENT_DATE",
+                "dataType": "int",
+                "value": "20362",
+                "unit": "days",
+                "ucd": "time",
+                "Description": "Trucated Julian day."
+            },
+            {
+                "name": "EVENT_TIME",
+                "datatype": "float",
+                "value": "31891.949",
+                "unit": "sec",
+                "ucd": "time",
+                "Description": "Seconds of the Day UT."
+            },
+            {
+                "name": "SRC_CLASS",
+                "dataType": "string",
+                "value": "GRB",
+                "Description": "The Event Type is a regular GRB."
+            },
+            {
+                "name": "BURST_INTEN",
+                "dataType": "int",
+                "value": "2152",
+                "unit": "[counts/sec]",
+                "Description": "Intensity of the burst in counts/sec."
+            },
+            {
+                "name": "BURST_DUR",
+                "dataType": "float",
+                "value": "1.000",
+                "unit": "[sec]",
+                "Description": "Duration of the event."
+            },
+            {
+                "name": "Phi",
+                "dataType": "float",
+                "value": "202.50",
+                "Description": "YET TO DO."
+            },
+            {
+                "name": "Theta",
+                "dataType": "float",
+                "value": "52.46",
+                "Description": "YET TO DO."
+            },
+            {
+                "name": "SC_LAT",
+                "dataType": "float",
+                "value": "-18.78",
+                "Description": "Spacecraft location."
+            },
+            {
+                "name": "SC_LONG",
+                "dataType": "float",
+                "value": "24.54",
+                "Description": "Spacecraft location."
+            }
+        ]
+    },
+    "WhereWhen": {
+        "ObsDataLocation": {
+            "ObservatoryLocation": {
+                "id": "GEOLUN"
+            },
+            "ObservationLocation": {
+                "AstroCoordSystem": {
+                    "id": "UTC-FK5-GEO"
+                },
+                "AstroCoords": {
+                    "coord_system_id": "UTC-FK5-GEO",
+                    "Time": {
+                        "unit": "s",
+                        "TimeInstant": {
+                            "ISOTime": "2024-02-22T08:51:31.95"
+                        }
+                    },
+                    "Position2D": {
+                        "unit": "deg",
+                        "Name1": "RA",
+                        "Name2": "Dec",
+                        "Value2": {
+                            "C1": "165.4300",
+                            "C2": "-68.6999"
+                        },
+                        "Error2Radius": "21.5500"
+                    }
+                }
+            }
+        },
+        "Description": "The RA,Dec coordinates are of the type: source_object."
+    },
+    "How": {
+        "Description": "GECAM GROUND",
+        "Reference": {
+            "uri": "http://gcn.gsfc.nasa.gov/gcn/gecam.html",
+            "type": "url"
+        }
+    },
+    "Why": {
+        "importance": "1.0",
+        "Inference": {
+            "probability": "1.0",
+            "Concept": "process.variation.burst;em"
+        }
+    },
+    "Citations": {},
+    "Description": null,
+    "Reference": {}
+}

--- a/gtecs/alert/data/test_notices/Swift/1216804-BAT_GRB_POS-GRB_240222A.json
+++ b/gtecs/alert/data/test_notices/Swift/1216804-BAT_GRB_POS-GRB_240222A.json
@@ -1,0 +1,481 @@
+{
+    "ivorn": "ivo://nasa.gsfc.gcn/SWIFT#BAT_GRB_Pos_1216804-868",
+    "role": "observation",
+    "version": "2.0",
+    "Who": {
+        "AuthorIVORN": "ivo://nasa.gsfc.tan/gcn",
+        "Author": {
+            "shortName": "VO-GCN",
+            "contactName": "Scott Barthelmy",
+            "contactPhone": "+1-301-286-3106",
+            "contactEmail": "scott.barthelmy@nasa.gov"
+        },
+        "Date": "2024-02-22T08:51:48",
+        "Description": "This VOEvent message was created with GCN VOE version: 15.08 17jun22"
+    },
+    "What": {
+        "Param": [
+            {
+                "name": "Packet_Type",
+                "value": "61"
+            },
+            {
+                "name": "Pkt_Ser_Num",
+                "value": "18"
+            },
+            {
+                "name": "TrigID",
+                "value": "1216804",
+                "ucd": "meta.id"
+            },
+            {
+                "name": "Segment_Num",
+                "value": "0",
+                "ucd": "meta.id.part"
+            },
+            {
+                "name": "Burst_TJD",
+                "value": "20362",
+                "unit": "days",
+                "ucd": "time"
+            },
+            {
+                "name": "Burst_SOD",
+                "value": "31891.32",
+                "unit": "sec",
+                "ucd": "time"
+            },
+            {
+                "name": "Burst_Inten",
+                "value": "3160",
+                "unit": "cts",
+                "ucd": "phot.count;em.gamma.soft"
+            },
+            {
+                "name": "Burst_Peak",
+                "value": "205",
+                "unit": "cts",
+                "ucd": "phot.count;em.gamma.soft"
+            },
+            {
+                "name": "Integ_Time",
+                "value": "1.024",
+                "unit": "sec",
+                "ucd": "time.interval"
+            },
+            {
+                "name": "Phi",
+                "value": "-157.90",
+                "unit": "deg",
+                "ucd": "pos.az.azi"
+            },
+            {
+                "name": "Theta",
+                "value": "24.29",
+                "unit": "deg",
+                "ucd": "pos.az.zd"
+            },
+            {
+                "name": "Trig_Index",
+                "value": "155"
+            },
+            {
+                "name": "Soln_Status",
+                "value": "0x20000003"
+            },
+            {
+                "name": "Misc_flags",
+                "value": "0x0"
+            },
+            {
+                "name": "Cat_Num",
+                "value": "0"
+            },
+            {
+                "name": "Rate_Signif",
+                "value": "29.22",
+                "unit": "sigma",
+                "ucd": "stat.snr"
+            },
+            {
+                "name": "Image_Signif",
+                "value": "9.35",
+                "unit": "sigma",
+                "ucd": "stat.snr"
+            },
+            {
+                "name": "Bkg_Inten",
+                "value": "14313",
+                "unit": "cts",
+                "ucd": "phot.count"
+            },
+            {
+                "name": "Bkg_Time",
+                "value": "08:51:19.04",
+                "ucd": "time.start"
+            },
+            {
+                "name": "Bkg_Dur",
+                "value": "8.00",
+                "unit": "sec",
+                "ucd": "time.duration"
+            },
+            {
+                "name": "SC_Long",
+                "value": "201.49",
+                "unit": "deg",
+                "ucd": "pos.earth.lon"
+            },
+            {
+                "name": "SC_Lat",
+                "value": "-6.57",
+                "unit": "deg",
+                "ucd": "pos.earth.lat"
+            },
+            {
+                "name": "Coords_Type",
+                "value": "1",
+                "unit": "dn"
+            },
+            {
+                "name": "Coords_String",
+                "value": "source_object"
+            }
+        ],
+        "Group": [
+            {
+                "name": "Merit_Values",
+                "Param": [
+                    {
+                        "name": "Merit_Val0",
+                        "value": "1",
+                        "unit": "dn"
+                    },
+                    {
+                        "name": "Merit_Val1",
+                        "value": "0",
+                        "unit": "dn"
+                    },
+                    {
+                        "name": "Merit_Val2",
+                        "value": "0",
+                        "unit": "dn"
+                    },
+                    {
+                        "name": "Merit_Val3",
+                        "value": "0",
+                        "unit": "dn"
+                    },
+                    {
+                        "name": "Merit_Val4",
+                        "value": "3",
+                        "unit": "dn"
+                    },
+                    {
+                        "name": "Merit_Val5",
+                        "value": "0",
+                        "unit": "dn"
+                    },
+                    {
+                        "name": "Merit_Val6",
+                        "value": "0",
+                        "unit": "dn"
+                    },
+                    {
+                        "name": "Merit_Val7",
+                        "value": "0",
+                        "unit": "dn"
+                    },
+                    {
+                        "name": "Merit_Val8",
+                        "value": "19",
+                        "unit": "dn"
+                    },
+                    {
+                        "name": "Merit_Val9",
+                        "value": "0",
+                        "unit": "dn"
+                    }
+                ]
+            },
+            {
+                "name": "Solution_Status",
+                "Param": [
+                    {
+                        "name": "Point_Source",
+                        "value": "true"
+                    },
+                    {
+                        "name": "GRB_Identified",
+                        "value": "true"
+                    },
+                    {
+                        "name": "Target_of_Interest",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Target_Imag_Trig",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Target_Rate_Trig",
+                        "value": "true"
+                    },
+                    {
+                        "name": "Def_NOT_a_GRB",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Hi_Bkg_Level",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Neg_Bkg_Slope",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Lo_Image_Signif",
+                        "value": "false"
+                    },
+                    {
+                        "name": "VERY_Lo_Image_Signif",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Target_in_Flt_Catalog",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Target_in_Gnd_Catalog",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Target_in_Blk_Catalog",
+                        "value": "false"
+                    },
+                    {
+                        "name": "StarTrack_Lost_Lock",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Near_Bright_Star",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Src_Removed_from_OnBoard",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Converted_SubThresh",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Spatial_Prox_Match",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Temporal_Prox_Match",
+                        "value": "true"
+                    },
+                    {
+                        "name": "Test_Submission",
+                        "value": "false"
+                    }
+                ]
+            },
+            {
+                "name": "Misc_Flags",
+                "Param": [
+                    {
+                        "name": "Values_Out_of_Range",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Already_Observing_Position",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Near_Bright_Star",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Err_Circle_in_Galaxy",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Galaxy_in_Err_Circle",
+                        "value": "false"
+                    },
+                    {
+                        "name": "ImTrig_during_ST_LoL",
+                        "value": "false"
+                    },
+                    {
+                        "name": "TOO_Generated",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Trig_time_is_SecHdrTime",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Delayed_Transmission",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Updated_Notice",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Flt_Generated",
+                        "value": "true"
+                    },
+                    {
+                        "name": "Gnd_Generated",
+                        "value": "false"
+                    },
+                    {
+                        "name": "SERS_Generated",
+                        "value": "false"
+                    },
+                    {
+                        "name": "Other_Generated",
+                        "value": "false"
+                    },
+                    {
+                        "name": "CRC_Error",
+                        "value": "false"
+                    }
+                ]
+            },
+            {
+                "name": "Obs_Support_Info",
+                "Description": "The Sun and Moon values are valid at the time the VOEvent XML message was created.",
+                "Param": [
+                    {
+                        "name": "Sun_RA",
+                        "value": "335.15",
+                        "unit": "deg",
+                        "ucd": "pos.eq.ra"
+                    },
+                    {
+                        "name": "Sun_Dec",
+                        "value": "-10.32",
+                        "unit": "deg",
+                        "ucd": "pos.eq.dec"
+                    },
+                    {
+                        "name": "Sun_Distance",
+                        "value": "101.09",
+                        "unit": "deg",
+                        "ucd": "pos.angDistance"
+                    },
+                    {
+                        "name": "Sun_Hr_Angle",
+                        "value": "-11.21",
+                        "unit": "hr"
+                    },
+                    {
+                        "name": "Moon_RA",
+                        "value": "133.33",
+                        "unit": "deg",
+                        "ucd": "pos.eq.ra"
+                    },
+                    {
+                        "name": "Moon_Dec",
+                        "value": "22.40",
+                        "unit": "deg",
+                        "ucd": "pos.eq.dec"
+                    },
+                    {
+                        "name": "MOON_Distance",
+                        "value": "90.84",
+                        "unit": "deg",
+                        "ucd": "pos.angDistance"
+                    },
+                    {
+                        "name": "Moon_Illum",
+                        "value": "95.79",
+                        "unit": "%",
+                        "ucd": "arith.ratio"
+                    },
+                    {
+                        "name": "Galactic_Long",
+                        "value": "286.00",
+                        "unit": "deg",
+                        "ucd": "pos.galactic.lon"
+                    },
+                    {
+                        "name": "Galactic_Lat",
+                        "value": "-11.95",
+                        "unit": "deg",
+                        "ucd": "pos.galactic.lat"
+                    },
+                    {
+                        "name": "Ecliptic_Long",
+                        "value": "208.61",
+                        "unit": "deg",
+                        "ucd": "pos.ecliptic.lon"
+                    },
+                    {
+                        "name": "Ecliptic_Lat",
+                        "value": "-70.03",
+                        "unit": "deg",
+                        "ucd": "pos.ecliptic.lat"
+                    }
+                ]
+            }
+        ],
+        "Description": "Type=61: The Swift-BAT instrument position notice."
+    },
+    "WhereWhen": {
+        "ObsDataLocation": {
+            "ObservatoryLocation": {
+                "id": "GEOLUN"
+            },
+            "ObservationLocation": {
+                "AstroCoordSystem": {
+                    "id": "UTC-FK5-GEO"
+                },
+                "AstroCoords": {
+                    "coord_system_id": "UTC-FK5-GEO",
+                    "Time": {
+                        "unit": "s",
+                        "TimeInstant": {
+                            "ISOTime": "2024-02-22T08:51:31.32"
+                        }
+                    },
+                    "Position2D": {
+                        "unit": "deg",
+                        "Name1": "RA",
+                        "Name2": "Dec",
+                        "Value2": {
+                            "C1": "143.2478",
+                            "C2": "-68.0289"
+                        },
+                        "Error2Radius": "0.0500"
+                    }
+                }
+            }
+        },
+        "Description": "The RA,Dec coordinates are of the type: source_object."
+    },
+    "How": {
+        "Description": "Swift Satellite, BAT Instrument",
+        "Reference": {
+            "uri": "http://gcn.gsfc.nasa.gov/swift.html",
+            "type": "url"
+        }
+    },
+    "Why": {
+        "importance": "0.90",
+        "Inference": {
+            "probability": "0.90",
+            "Name": "GRB 240222",
+            "Concept": "process.variation.burst;em.gamma"
+        }
+    },
+    "Citations": {},
+    "Description": null,
+    "Reference": {}
+}

--- a/gtecs/alert/database.py
+++ b/gtecs/alert/database.py
@@ -74,7 +74,7 @@ def session_manager(**kwargs):
 
 
 class Event(Base):
-    """A class to represent a transient astrophysical Event.
+    """A class to represent a transient detection of an astrophysical Event.
 
     Events can be linked to Notices, with a specific event (e.g. GW170817)
     potentially producing multiple Notices as the skymap is updated.
@@ -98,6 +98,8 @@ class Event(Base):
     ---------------------
     notices : list of `Notice`, optional
         the Notices relating to this Event, if any
+    coincidence : `Coincidence`, optional
+        the Coincidence group for this Event, if any
 
     Attributes
     ----------
@@ -125,6 +127,9 @@ class Event(Base):
     origin = Column(String(255), nullable=False)
     time = Column(DateTime, nullable=True, default=None)
 
+    # Foreign keys
+    coincidence_id = Column(Integer, ForeignKey('alert.coincidences.id'), nullable=True)
+
     # Update timestamp
     ts = Column(DateTime, nullable=False, server_default=func.now())
 
@@ -133,6 +138,11 @@ class Event(Base):
         'Notice',
         order_by='Notice.db_id',
         back_populates='event',
+    )
+    coincidence = relationship(
+        'Coincidence',
+        order_by='Coincidence.db_id',
+        back_populates='events',
     )
 
     # Secondary relationships
@@ -265,6 +275,15 @@ class Notice(Base):
         ),
         viewonly=True,
     )
+    coincidence = relationship(
+        'Coincidence',
+        order_by='Coincidence.db_id',
+        secondary='alert.events',
+        primaryjoin='Event.db_id == Notice.event_id',
+        secondaryjoin='Coincidence.db_id == Event.coincidence_id',
+        back_populates='notices',
+        viewonly=True,
+    )
 
     def __repr__(self):
         strings = ['ivorn={}'.format(self.ivorn),
@@ -331,6 +350,63 @@ class Notice(Base):
             # Decode the bytes
             notice.skymap = SkyMap.from_fits(self.skymap)
         return notice
+
+
+class Coincidence(Base):
+    """A class to represent a coincidental link between multiple Events.
+
+    While Events are linked to a specific origin (e.g. LVC, Fermi, IceCube),
+    Coincidences are used to link multiple Events from different origins together.
+    For instance a GRB could be detected by multiple satellites (Fermi, Swift, GECAM, etc).
+
+    Attributes
+    ----------
+    db_id : int
+        primary database key
+        only populated when the instance is added to the database
+
+    Secondary relationships
+    -----------------------
+    events : list of `gtecs.alert.database.Event`
+        the Events relating to this Coincidence, if any
+    notices : list of `gtecs.alert.database.Notice`
+        the Notices relating to this Coincidence, if any
+
+    """
+
+    # Set corresponding SQL table name
+    __tablename__ = 'coincidences'
+    __table_args__ = {'schema': 'alert'}
+
+    # Primary key
+    db_id = Column('id', Integer, primary_key=True)
+
+    # Update timestamp
+    ts = Column(DateTime, nullable=False, server_default=func.now())
+
+    # Foreign relationships
+    events = relationship(
+        'Event',
+        order_by='Event.db_id',
+        back_populates='coincidence',
+    )
+
+    # Secondary relationships
+    notices = relationship(
+        'Notice',
+        order_by='Notice.db_id',
+        secondary='alert.events',
+        primaryjoin='Event.coincidence_id == Coincidence.db_id',
+        secondaryjoin='Notice.event_id == Event.db_id',
+        back_populates='coincidence',
+        viewonly=True,
+        uselist=True,
+    )
+
+    def __repr__(self):
+        strings = ['db_id={}'.format(self.db_id),
+                   ]
+        return 'Coincidence({})'.format(', '.join(strings))
 
 
 # Registries for other entities

--- a/gtecs/alert/handler.py
+++ b/gtecs/alert/handler.py
@@ -7,9 +7,8 @@ from astropy.time import Time
 
 from gtecs.obs import database as obs_db
 
-import numpy as np
-
 from . import database as alert_db
+from .coincidence import find_coincident_events
 from .slack import send_notice_report, send_observing_report, send_slack_msg
 
 
@@ -22,6 +21,7 @@ def already_in_database(notice):
         if db_notice is not None:
             return True
     return False
+
 
 def add_notice_to_database(notice, log=None):
     """Add an entry for the given Notice to the alert database.
@@ -177,140 +177,6 @@ def add_survey_to_database(notice, time=None, log=None):
 
     return survey_id
 
-
-def get_skymap_overlap(skymap1, skymap2, contour=0.95, regrade_nside=128):
-    """Get the overlap fraction between two skymaps at a given contour level.
-
-    TODO: This could be a method on the gototile.SkyMap class
-    """
-    # Regrade each skymap to the same nside
-    # TODO: It would be nice if it returned a new skymap (with inplace=False)
-    #       instead of modifying the original one.
-    if skymap1.nside != regrade_nside:
-        skymap1 = skymap1.copy()
-        skymap1.regrade(nside=regrade_nside)
-    if skymap2.nside != regrade_nside:
-        skymap2 = skymap2.copy()
-        skymap2.regrade(nside=regrade_nside)
-
-    # Get the pixel indices within the contour level
-    contour_ipix1 = set(np.where(skymap1.contours<contour)[0])
-    contour_ipix2 = set(np.where(skymap2.contours<contour)[0])
-    intersection = contour_ipix1.intersection(contour_ipix2)
-    if len(intersection) == 0:
-        return 0.0
-
-    # We want to return the biggest overlap fraction
-    # (i.e. the fraction of the smaller skymap that overlaps with the larger one)
-    return len(intersection) / min(len(contour_ipix1), len(contour_ipix2))
-
-
-def get_tile_overlap(notice1, notice2):
-    """Get the overlap fraction between two notice tilesets.
-
-    Returns the fraction of the smaller set that overlaps with the larger one.
-    """
-    selected1 = notice1.select_tiles()
-    selected2 = notice2.select_tiles()
-    tile_set1 = set(selected1['tilename'])
-    tile_set2 = set(selected2['tilename'])
-    intersection = tile_set1.intersection(tile_set2)
-    if len(intersection) == 0:
-        return 0.0
-
-    # We want to return the biggest overlap fraction
-    # (i.e. the fraction of the smaller set that overlaps with the larger one)
-    return len(intersection) / min(len(tile_set1), len(tile_set2))
-
-
-def find_coincident_events(
-        notice,
-        time_window=10,
-        skymap_contour=0.95,
-        type_limit=True,
-        return_parameters=False
-    ):
-    """Check the AlertDB for any other events with matching times and positions.
-
-    Parameters
-    ----------
-    notice : `gtecs.alert.notices.Notice`
-        The notice to check for coincidences with.
-
-    time_window : float, optional
-        The time window (in seconds) from the event time to check for coincidences.
-        Default is 10 seconds.
-    skymap_contour : float, optional
-        The contour level to use for the skymap overlap check.
-        Default is 0.95 (i.e. the 95% contour level).
-    type_limit : bool, optional
-        If True, only check for events of the same type as the given notice.
-        Default is True.
-    return_parameters : bool, optional
-        If True, return the time difference, skymap overlap, and tile overlap
-        for each matching event.
-        Default is False.
-        If False, only return the matching event IDs.
-
-    Returns
-    -------
-    matching_events : list of int or list of tuples
-        If `return_parameters` is False, a list of database IDs for any matching events.
-        If `return_parameters` is True, a list of tuples containing the database ID,
-        time difference, skymap overlap, and tile overlap for each matching event.
-        Each tuple is of the form (db_id, time_diff, skymap_overlap, tile_overlap).
-        The time difference is in seconds, and the skymap and tile overlaps are fractions
-        between 0 and 1.
-        If no matches are found, an empty list is returned.
-
-    """
-    with alert_db.session_manager() as session:
-        # Get any Events from the database that have a matching event time
-        query = session.query(alert_db.Event)
-        query = query.filter(alert_db.Event.time >= notice.event_time - time_window * u.second)
-        query = query.filter(alert_db.Event.time <= notice.event_time + time_window * u.second)
-        query = query.filter(alert_db.Event.name != notice.event_name) # Don't include this event!
-        if type_limit:
-            query = query.filter(alert_db.Event.type == notice.event_type)
-        db_events = query.all()
-
-        # Nothing within the time window
-        if len(db_events) == 0:
-            return []
-
-        # We found some, but we want to check if any of them overlap with this notice's skymap
-        # We want to check both the notice skymaps and the selected tiles,
-        # as either overlapping should trigger a match.
-        matching_events = []
-        for db_event in db_events:
-            # We only care about the latest notice for each event,
-            # any previous ones should have already been deleted.
-            event_notice = db_event.notices[-1].gcn
-            time_diff = (event_notice.event_time - notice.event_time).value
-
-            # Check if either of the notice skymaps or tilesets overlap
-            skymap_overlap = get_skymap_overlap(
-                notice.skymap, event_notice.skymap, contour=skymap_contour
-            )
-            tile_overlap = get_tile_overlap(notice, event_notice)
-            if tile_overlap == 0 and skymap_overlap == 0:
-                # Neither overlap, so the time must have been a coincidence
-                continue
-
-            # We have a match!
-            if return_parameters:
-                params = (
-                    db_event.db_id,
-                    time_diff,
-                    skymap_overlap,
-                    tile_overlap
-                )
-                matching_events.append(params)
-            else:
-                # Just append the event ID
-                matching_events.append(db_event.db_id)
-
-    return matching_events
 
 def check_coincident_events(notice, time_window=10, skymap_contour=0.95, time=None, log=None):
     """Check the AlertDB for any events with matching times and tile sets.

--- a/gtecs/alert/handler.py
+++ b/gtecs/alert/handler.py
@@ -205,6 +205,85 @@ def get_skymap_overlap(skymap1, skymap2, contour=0.95, regrade_nside=128):
     return len(intersection) / min(len(contour_ipix1), len(contour_ipix2))
 
 
+def get_tile_overlap(notice1, notice2):
+    """Get the overlap fraction between two notice tilesets.
+
+    Returns the fraction of the smaller set that overlaps with the larger one.
+    """
+    selected1 = notice1.select_tiles()
+    selected2 = notice2.select_tiles()
+    tile_set1 = set(selected1['tilename'])
+    tile_set2 = set(selected2['tilename'])
+    intersection = tile_set1.intersection(tile_set2)
+    if len(intersection) == 0:
+        return 0.0
+
+    # We want to return the biggest overlap fraction
+    # (i.e. the fraction of the smaller set that overlaps with the larger one)
+    return len(intersection) / min(len(tile_set1), len(tile_set2))
+
+
+def find_coincident_events(notice, time_window=10, skymap_contour=0.95, type_limit=True):
+    """Check the AlertDB for any other events with matching times and positions.
+
+    Parameters
+    ----------
+    notice : `gtecs.alert.notices.Notice`
+        The notice to check for coincidences with.
+
+    time_window : float, optional
+        The time window (in seconds) from the event time to check for coincidences.
+        Default is 10 seconds.
+    skymap_contour : float, optional
+        The contour level to use for the skymap overlap check.
+        Default is 0.95 (i.e. the 95% contour level).
+    type_limit : bool, optional
+        If True, only check for events of the same type as the given notice.
+        Default is True.
+
+    Returns
+    -------
+    matching_events : list of int
+        A list of database IDs for any matching events.
+        If no matches are found, an empty list is returned.
+    """
+    with alert_db.session_manager() as session:
+        # Get any Events from the database that have a matching event time
+        query = session.query(alert_db.Event)
+        query = query.filter(alert_db.Event.time >= notice.event_time - time_window * u.second)
+        query = query.filter(alert_db.Event.time <= notice.event_time + time_window * u.second)
+        query = query.filter(alert_db.Event.name != notice.event_name) # Don't include this event!
+        if type_limit:
+            query = query.filter(alert_db.Event.type == notice.event_type)
+        db_events = query.all()
+
+        # Nothing within the time window
+        if len(db_events) == 0:
+            return []
+
+        # We found some, but we want to check if any of them overlap with this notice's skymap
+        # We want to check both the notice skymaps and the selected tiles,
+        # as either overlapping should trigger a match.
+        matching_events = []
+        for db_event in db_events:
+            # We only care about the latest notice for each event,
+            # any previous ones should have already been deleted.
+            event_notice = db_event.notices[-1].gcn
+
+            # Check if either of the notice skymaps or tilesets overlap
+            skymap_overlap = get_skymap_overlap(
+                notice.skymap, event_notice.skymap, contour=skymap_contour
+            )
+            tile_overlap = get_tile_overlap(notice, event_notice)
+            if tile_overlap == 0 and skymap_overlap == 0:
+                # Neither overlap, so the time must have been a coincidence
+                continue
+
+            # We have a match!
+            matching_events.append(db_event.db_id)
+
+    return matching_events
+
 def check_coincident_events(notice, time_window=10, skymap_contour=0.95, time=None, log=None):
     """Check the AlertDB for any events with matching times and tile sets.
 
@@ -225,59 +304,44 @@ def check_coincident_events(notice, time_window=10, skymap_contour=0.95, time=No
         log = logging.getLogger('database')
         log.setLevel(level=logging.DEBUG)
 
-    # We should have already selected the tiles for this notice
-    selected_tiles = notice.select_tiles()
-    tile_set = set(selected_tiles['tilename'])
+    # Find any overlapping events
+    coincident_events = find_coincident_events(
+        notice, time_window=time_window, skymap_contour=skymap_contour
+    )
+    if len(coincident_events) == 0:
+        # No matching events found, so nothing to do
+        log.debug('No coincident events found')
+        return False
+    log.info(f'Found {len(coincident_events)} coincident events')
 
-    found_better_event = False
+    # There are matching events, now we want to go through and check if any of them
+    # are "better" than this one.
     with alert_db.session_manager() as session:
-        # Get any Events from the database that have a matching event time
-        query = session.query(alert_db.Event)
-        query = query.filter(alert_db.Event.time >= notice.event_time - time_window * u.second)
-        query = query.filter(alert_db.Event.time <= notice.event_time + time_window * u.second)
-        query = query.filter(alert_db.Event.name != notice.event_name) # Don't include this event!
-        db_events = query.all()
+        found_better = False
+        for db_event_id in coincident_events:
+            # Get the event ant latest notice from the database
+            db_event = session.query(alert_db.Event).filter_by(db_id=db_event_id).one()
+            event_notice = db_event.notices[-1].gcn
+            log.info(f'Coincident event: {db_event.name}')
+            log.info(f'Latest notice: {event_notice.ivorn}')
 
-        # If there are no matching events then we just want to add this one, so return False
-        if len(db_events) == 0:
-            log.debug('No matching events found')
-            return found_better_event
-
-        log.debug(f'Found {len(db_events)} events within {time_window:.0f}s of {notice.event_time}')
-
-        # Now check if any of the events  overlap with this notice
-        # We want to check both the notice skymaps and the selected tiles,
-        # as either overlapping should trigger a match.
-        for db_event in db_events:
-            # We only care about the latest notice for each event,
-            # any previous ones should have already been deleted.
-            db_notice = db_event.notices[-1]
-            log.info(f'Coincident notice: {db_notice.ivorn}')
-            if len(db_notice.targets) == 0:
+            # Check if the notice has any targets
+            if len(db_event.notices[-1].targets) == 0:
                 # No targets for this notice (might have been below min_prob), so we can ignore it
                 log.info('Notice has no targets defined')
                 continue
 
-            # Check if either of the notice skymaps overlap
+            # Get the parameters
+            # Yes this is duplicating what happens in find_coincident_notices(),
+            # but that doesn't include logging.
+            time_diff = abs(event_notice.event_time - notice.event_time)
             skymap_overlap = get_skymap_overlap(
-                notice.skymap, db_notice.gcn.skymap, contour=skymap_contour
+                notice.skymap, event_notice.skymap, contour=skymap_contour
             )
-            log.debug(f'Skymap overlap = {skymap_overlap > 0} ({skymap_overlap:.0%})')
-
-            # Check if any of the selected tiles overlap
-            old_tiles = [target.grid_tile.name for target in db_notice.targets]
-            old_tile_set = set(old_tiles)
-            tile_overlap = len(tile_set.intersection(old_tile_set))
-            tile_overlap /= min(len(tile_set), len(old_tile_set))
-            log.debug(f'Tile overlap = {tile_overlap > 0} ({tile_overlap:.0%})')
-
-            if tile_overlap == 0 and skymap_overlap == 0:
-                # Neither overlap, so the time must have been a coincidence
-                log.info('No overlap detected')
-                continue
-
-            # We have a match!
-            log.info('Overlap detected')
+            tile_overlap = get_tile_overlap(notice, event_notice)
+            log.debug(f'Time difference: {time_diff.value:.1f}s')
+            log.debug(f'Skymap overlap: {skymap_overlap:.0%}')
+            log.debug(f'Tile overlap: {tile_overlap:.0%}')
 
             # Now we want to decide which notice is best to observe.
             # It's not actually that obvious. We could compare the size of the skymaps or
@@ -285,10 +349,13 @@ def check_coincident_events(notice, time_window=10, skymap_contour=0.95, time=No
             # case where a smaller skymap had more tiles added to the ObsDB.
             # Easiest is just to go with the skymap area for which event better localised and
             # therefore closer to the "real" position.
-            old_area = db_notice.gcn.skymap.get_contour_area(skymap_contour)
+            old_area = event_notice.skymap.get_contour_area(skymap_contour)
             new_area = notice.skymap.get_contour_area(skymap_contour)
+            log.debug(f'Old skymap area: {old_area:.2f} deg2')
+            log.debug(f'New skymap area: {new_area:.2f} deg2')
             if new_area < old_area:
-                # This new notice is smaller, so we want to keep it and delete the old targets.
+                # This new notice is smaller, so we want to keep it and delete all the old targets
+                # for the previous event.
                 # If there are multiple previous Surveys then all but the latest should have already
                 # been deleted, but we might as well go through and check to be sure.
                 log.info('New notice skymap is smaller, deleting existing targets')
@@ -297,9 +364,9 @@ def check_coincident_events(notice, time_window=10, skymap_contour=0.95, time=No
             else:
                 # The new notice is worse, so we want to ignore it and keep the existing targets.
                 log.info('New notice skymap is larger, leaving existing targets')
-                found_better_event = True
+                found_better = True
 
-        return found_better_event
+        return found_better
 
 def add_targets_to_database(notice, time=None, log=None):
     """Add Targets for the given notice to the observation database.

--- a/gtecs/alert/handler.py
+++ b/gtecs/alert/handler.py
@@ -208,31 +208,96 @@ def check_coincident_events(notice, time_window=10, skymap_contour=0.95, time=No
         return False
     log.info(f'Found {len(coincident_events)} coincident events')
 
-    # There are matching events, now we want to go through and check if any of them
-    # are "better" than this one.
+    # There are matching events, great!
+    # Now we want to go through each of them and log the coincidence, then check if any of
+    # their notices are are "better" than this one.
     with alert_db.session_manager() as session:
-        found_better = False
-        for event_parameters in coincident_events:
-            # Get the event ID and parameters
-            db_event_id, time_diff, skymap_overlap, tile_overlap = event_parameters
+        # Get the event for the current notice
+        db_notice = session.query(alert_db.Notice).filter_by(ivorn=notice.ivorn).one()
+        db_event = db_notice.event
 
-            # Get the event ant latest notice from the database
-            db_event = session.query(alert_db.Event).filter_by(db_id=db_event_id).one()
-            event_notice = db_event.notices[-1].gcn
-            log.info(f'Coincident event: {db_event.name}')
-            log.info(f'Latest notice: {event_notice.ivorn}')
+        found_better = False
+        for matched_event_id, time_diff, skymap_overlap, tile_overlap in coincident_events:
+            # Get the event and latest notice from the database
+            matched_event = session.query(alert_db.Event).filter_by(db_id=matched_event_id).one()
+            log.info(f'Coincident event: {matched_event.name}')
+
+            # Create a Coincidence group for this Event, or add it to an existing one
+            if matched_event.coincidence is None and db_event.coincidence is None:
+                # Create a new Coincidence group
+                db_coincidence = alert_db.Coincidence()
+                session.add(db_coincidence)
+                session.commit()
+                # Link this old event and the new one to the new Coincidence group
+                matched_event.coincidence = db_coincidence
+                db_event.coincidence = db_coincidence
+                log.debug(f'Creating new Coincidence group {db_coincidence.db_id}')
+            elif db_event.coincidence is None:
+                # The matched Event is already part of a Coincidence group,
+                # so we just need to add our new event to it
+                db_event.coincidence = matched_event.coincidence
+                log.debug(f'Extending Coincidence group {matched_event.coincidence.db_id}')
+            else:
+                # Somehow our new Event is already in a Coincidence group.
+                # This could happen if we're looping through matched events, and we've just
+                # added or created a new group.
+                # Or this is an update notice for an already-existing event.
+                if matched_event.coincidence == db_event.coincidence:
+                    # That's fine, they're already in the same group.
+                    log.debug(f'Already in Coincidence group {db_event.coincidence.db_id}')
+                elif matched_event.coincidence is None:
+                    # The matched Event is not in a Coincidence group, so we can add it to ours.
+                    # This could happen if Event A and Event B weren't matched,
+                    # now Event C comes along and matches both. So we created a new group with
+                    # Event A, and now we backfill it onto Event B.
+                    matched_event.coincidence = db_event.coincidence
+                    log.debug(f'Backfilling Coincidence group {db_event.coincidence.db_id}')
+                else:
+                    # Here we have a problem, our new Event is in a different group
+                    # than this one that was matched to it.
+                    # This should be very uncommon, but it could happen e.g.
+                    # - Event A and B have identical timestamps and are grouped together,
+                    # - Event C and D have a different timestamp 11 seconds away from the first,
+                    #   so they're grouped together into a new group,
+                    # - Event E has appears in between the two times, so is matched to all 4.
+                    # (this is assuming all their skymaps all overlap).
+                    # The matched events should be sorted by time, so if we've already matched
+                    # this new event to a group then we should keep it and move this matched event
+                    # into it.
+                    log.warning('Multiple Coincidence groups detected!')
+                    msg = f'Merging {matched_event.coincidence.db_id}'
+                    msg += ' into {db_event.coincidence.db_id}'
+                    log.warning(msg)
+                    # Now we have a problem because there might be other events in the second
+                    # group which weren't matched to this new notice!
+                    # So we need to query for them and change their group too.
+                    query = session.query(alert_db.Event)
+                    query = query.filter(alert_db.Event.coincidence==matched_event.coincidence)
+                    query = query.filter(alert_db.Event!=matched_event)
+                    grouped_events = query.all()
+                    # Now replace the groups for these events
+                    log.debug(f'Backfilling Coincidence group {db_event.coincidence.db_id}')
+                    matched_event.coincidence = db_event.coincidence
+                    for grouped_event in grouped_events:
+                        log.debug(f'Backfilling secondary Event {db_event.name}')
+                        grouped_event.coincidence = db_event.coincidence
+                    # This will leave an empty Coincidence row, which is a bit awkward,
+                    # but without some many-to-many option of Events being part of multiple groups
+                    # there's no easier option.
 
             # Check if the notice has any targets
-            if len(db_event.notices[-1].targets) == 0:
+            if len(matched_event.notices[-1].targets) == 0:
                 # No targets for this notice (might have been below min_prob), so we can ignore it
                 log.info('Notice has no targets defined')
                 continue
 
+            # Now we can actually look at the matched notice
+            # TODO: ADD SLACK MESSAGE
+            matched_notice = matched_event.notices[-1].gcn
+            log.info(f'Latest notice: {matched_notice.ivorn}')
             log.debug(f'Time difference: {time_diff:.3f}s')
             log.debug(f'Skymap overlap: {skymap_overlap:.0%}')
             log.debug(f'Tile overlap: {tile_overlap:.0%}')
-
-            # TODO: ADD SLACK MESSAGE
 
             # Now we want to decide which notice is best to observe.
             # It's not actually that obvious. We could compare the size of the skymaps or
@@ -240,7 +305,7 @@ def check_coincident_events(notice, time_window=10, skymap_contour=0.95, time=No
             # case where a smaller skymap had more tiles added to the ObsDB.
             # Easiest is just to go with the skymap area for which event better localised and
             # therefore closer to the "real" position.
-            old_area = event_notice.skymap.get_contour_area(skymap_contour)
+            old_area = matched_notice.skymap.get_contour_area(skymap_contour)
             new_area = notice.skymap.get_contour_area(skymap_contour)
             log.debug(f'Old skymap area: {old_area:.2f} deg2')
             log.debug(f'New skymap area: {new_area:.2f} deg2')

--- a/gtecs/alert/handler.py
+++ b/gtecs/alert/handler.py
@@ -315,7 +315,7 @@ def check_coincident_events(notice, time_window=10, skymap_contour=0.95, time=No
                 # If there are multiple previous Surveys then all but the latest should have already
                 # been deleted, but we might as well go through and check to be sure.
                 log.info('New notice skymap is smaller, deleting existing targets')
-                for db_survey in db_event.surveys:
+                for db_survey in matched_event.surveys:
                     delete_survey_targets(db_survey, time, log)
             else:
                 # The new notice is worse, so we want to ignore it and keep the existing targets.
@@ -323,6 +323,7 @@ def check_coincident_events(notice, time_window=10, skymap_contour=0.95, time=No
                 found_better = True
 
         return found_better
+
 
 def add_targets_to_database(notice, time=None, log=None):
     """Add Targets for the given notice to the observation database.

--- a/gtecs/alert/handler.py
+++ b/gtecs/alert/handler.py
@@ -21,20 +21,13 @@ def already_in_database(notice):
             return True
     return False
 
+def add_notice_to_database(notice):
+    """Add an entry for the given Notice to the alert database.
 
-def add_to_database(notice, time=None, log=None):
-    """Add entries for this notice into the database(s)."""
-    if time is None:
-        time = Time.now()
-    if log is None:
-        log = logging.getLogger('database')
-        log.setLevel(level=logging.DEBUG)
+    If a matching Event already exists, the Notice will be linked to it.
+    If not, a new Event will be created.
+    """
 
-    # First make sure we have the skymap
-    if notice.skymap is None:
-        notice.get_skymap()  # May still be None if it's a retraction
-
-    # Add to the alert database
     with alert_db.session_manager() as session:
         # Get any matching Event from the database, or make one if it's new
         query = session.query(alert_db.Event)
@@ -48,7 +41,14 @@ def add_to_database(notice, time=None, log=None):
                 time=notice.event_time,
             )
 
-        # Now add the Notice (we'll update the survey ID later)
+        # Make sure we have the notice skymap
+        if notice.skymap is None:
+            notice.get_skymap()  # May still be None if it's a retraction
+
+        # Now add the Notice (no Survey ID for now, we'll update that later if we add one)
+        # TODO: We should store the Skymap in its own table
+        # TODO: Also we should store other supplementary data like the GWSkyNet scores somewhere
+        #       Could its own table, or as an extra field in the Notice table
         db_notice = alert_db.Notice.from_gcn(notice)
         db_notice.event = db_event
         try:
@@ -60,106 +60,144 @@ def add_to_database(notice, time=None, log=None):
             else:
                 raise
 
-        # Find how many previous surveys there have been for this event
-        event_surveys = [survey.db_id for survey in db_event.surveys]
-        log.debug(f'Found {len(event_surveys)} previous surveys for this event')
+        return db_notice.db_id
 
-        if len(event_surveys) > 0:
+
+def add_survey_to_database(notice, time=None, log=None):
+    """Add a Survey for the given Notice to the observation database.
+
+    This assumes we've already added the Notice to the alert database.
+
+    If the Event for this notice has any previous surveys, then
+    we'll check if the skymap or strategy has changed.
+    If so, we'll create a new Survey and delete the Targets for all previous ones.
+
+    If the notice has the IGNORE or RETRACTION strategy then no new Survey is created,
+    but we'll still delete any incomplete Targets from previous Surveys.
+    """
+    if time is None:
+        time = Time.now()
+    if log is None:
+        log = logging.getLogger('database')
+        log.setLevel(level=logging.DEBUG)
+
+    with alert_db.session_manager() as session:
+        # First get the Event from the database
+        db_notice = session.query(alert_db.Notice).filter_by(ivorn=notice.ivorn).one()
+
+        # Now find how many previous Surveys have been defined for this Event (if any)
+        db_event = db_notice.event
+        log.debug(f'Found {len(db_event.surveys)} previous surveys for this event')
+
+        requires_update = False
+        if len(db_event.surveys) == 0:
+            # There are no previous Surveys, so we'll want to create one.
+            requires_update = True
+        else:
+            # There are existing Surveys for this Event.
             # We want to see if the skymap or strategy has changed from the previous notice.
-            # If it has, we'll want to create a new survey.
-            # If there are previous surveys for this event, there should be previous notices.
-            last_dbnotice = db_event.notices[-2]  # (-1 would be the one we just created)
-            last_notice = last_dbnotice.gcn
+            # If it has, we'll want to create a new survey and targets and remove the old one.
+            last_db_notice = db_event.notices[-2]  # (-1 should be this one)
+            last_notice = last_db_notice.gcn
             log.debug(f'Previous notice {last_notice.ivorn} was received at {last_notice.time}')
-            requires_update = False
+
+            # Check if the skymap has changed
             if last_notice.skymap != notice.skymap:
                 log.info('Event skymap has been updated')
                 requires_update = True
             else:
                 log.info('Event skymap has not changed')
+
+            # Check if the strategy has changed
             if last_notice.strategy != notice.strategy:
-                msg = f'Event strategy has changed from {last_notice.strategy} to {notice.strategy}'
+                msg = 'Event strategy has changed'
+                msg += f' from {last_notice.strategy} to {notice.strategy}'
                 log.info(msg)
                 requires_update = True
             else:
                 log.info(f'Event strategy remains as {notice.strategy}')
 
-            if requires_update:
-                # Go through previous Surveys for this Event and "delete" any incomplete Targets.
-                # Using target.mark_deleted() will also delete any pending Pointings,
-                # but won't interrupt one if it's currently running.
-                # If there are multiple previous Surveys then all but the latest should have already
-                # been deleted, but we might as well go through and check to be sure.
-                for db_survey in db_event.surveys:
-                    num_deleted = 0
-                    for db_target in db_survey.targets:
-                        statuses = ['deleted', 'expired', 'completed']
-                        if db_target.status_at_time(time) not in statuses:
-                            db_target.mark_deleted(time=time)
-                            num_deleted += 1
-                    if num_deleted > 0:
-                        log.debug(f'Deleted {num_deleted} Targets for Survey {db_survey.name}')
-                    session.commit()
-        else:
-            # If there are no previous surveys, we'll want to create one.
-            requires_update = True
+        if requires_update:
+            # Go through any previous Surveys for this Event and "delete" any incomplete Targets.
+            # Using target.mark_deleted() will also delete any pending Pointings,
+            # but won't interrupt one if it's currently running.
+            # If there are multiple previous Surveys then all but the latest should have already
+            # been deleted, but we might as well go through and check to be sure.
+            for db_survey in db_event.surveys:
+                num_deleted = 0
+                for db_target in db_survey.targets:
+                    statuses = ['deleted', 'expired', 'completed']
+                    if db_target.status_at_time(time) not in statuses:
+                        db_target.mark_deleted(time=time)
+                        num_deleted += 1
+                if num_deleted > 0:
+                    log.debug(f'Deleted {num_deleted} Targets for Survey {db_survey.name}')
+                session.commit()
 
-    if notice.strategy in ['IGNORE', ' RETRACTION'] or notice.strategy_dict is None:
-        # Either it's an event we don't care about, or it's an explicit retraction notice.
-        # We've added it to the AlertDB and deleted the previous Targets, nothing else to do.
-        log.info(f'{notice.strategy} notice processed')
-        return
-    elif notice.skymap is None:
-        # We have a strategy but no skymap, so we can't do anything?
-        raise ValueError('Notice has a strategy but no skymap')
+        if notice.strategy in ['IGNORE', ' RETRACTION'] or notice.strategy_dict is None:
+            # We've added the Notice to the database, but we don't need to add a new Survey.
+            # After deleting any old Targets above there's nothing else to do here.
+            return None
 
-    if requires_update is True:
-        # We know this notice has a new skymap (or strategy) so we want to create a new Survey.
-        with obs_db.session_manager() as session:
-            db_survey = obs_db.Survey(
-                name=f'{notice.event_name}_{len(event_surveys) + 1}',
-            )
-            log.debug('Adding Survey {} to database'.format(db_survey.name))
-            session.add(db_survey)
-            session.commit()
-            survey_id = db_survey.db_id
-    else:
-        # The existing Survey is fine, just get the ID.
-        with obs_db.session_manager() as session:
-            query = session.query(obs_db.Survey)
-            query = query.filter_by(name=f'{notice.event_name}_{len(event_surveys)}')
-            db_survey = query.one()
-            survey_id = db_survey.db_id
+        if not requires_update:
+            # Nothing new to add, we just need to link this Notice to the latest Survey.
+            db_notice.survey_id = db_event.surveys[-1].db_id
+            return None
 
-    # Update the Survey ID in the alert database, so we can map between the objects
-    with alert_db.session_manager() as session:
-        db_notice = session.query(alert_db.Notice).filter_by(ivorn=notice.ivorn).one()
+        # Otherwise we know this notice has a new skymap (or strategy),
+        # so we want to create a new Survey.
+        db_survey = obs_db.Survey(name=f'{notice.event_name}_{len(db_event.surveys) + 1}')
+        log.debug('Adding Survey {} to database'.format(db_survey.name))
+        session.add(db_survey)
+        session.commit()
+        survey_id = db_survey.db_id
+
+        # Finally link the Notice to the new Survey.
         db_notice.survey_id = survey_id
 
-    if requires_update is False:
-        log.info('No changes to the skymap or strategy, so no update to the database required')
-        return
+    return survey_id
 
-    # Now select the grid tiles covering the skymap
-    log.debug('Selecting grid tiles')
+def select_tiles(notice):
+    """Select grid tiles for the given notice."""
     with obs_db.session_manager() as session:
         db_grid = obs_db.get_current_grid(session)
         grid = db_grid.skygrid
     grid_tiles = notice.get_tiles(grid)
+
     # Select tiles within the skymap contour and above the minimum probability threshold
     mask = ((grid_tiles['contour'] < notice.strategy_dict['skymap_contour']) &
             (grid_tiles['prob'] > notice.strategy_dict['min_tile_prob']))
     selected_tiles = grid_tiles[mask]
     selected_tiles.sort('prob', reverse=True)
+
     if len(selected_tiles) > notice.strategy_dict['max_tiles']:
         # Limit to only the N highest probability tiles
         selected_tiles = selected_tiles[:notice.strategy_dict['max_tiles']]
+
+    return selected_tiles, grid
+
+def add_targets_to_database(notice, time=None, log=None):
+    """Add Targets for the given notice to the observation database.
+
+    This assumes we've already added the Notice to the alert database,
+    and created a new Survey for it.
+
+    """
+    if time is None:
+        time = Time.now()
+    if log is None:
+        log = logging.getLogger('database')
+        log.setLevel(level=logging.DEBUG)
+
+    log.debug('Selecting grid tiles')
+    selected_tiles, grid = select_tiles(notice)
     log.debug('Selected {}/{} tiles'.format(len(selected_tiles), grid.ntiles))
+
     # It's possible no tiles passed the selection criteria,
-    # if so then there's nothing else to do (but we still add the "empty" survey above)
+    # if so then there's nothing else to do.
     if len(selected_tiles) < 1:
         log.warning('Nothing to add to the database')
-        return
+        return []
 
     # Create and add new Targets (and related entries) into the observation database
     with obs_db.session_manager() as session:
@@ -171,7 +209,11 @@ def add_to_database(notice, time=None, log=None):
             db_user = obs_db.User('sentinel', '', 'Sentinel alert Listener')
         db_grid = obs_db.get_current_grid(session)
 
-        # Create Targets for each tile
+        # Get the survey ID from the notice
+        db_notice = session.query(alert_db.Notice).filter_by(ivorn=notice.ivorn).one()
+        survey_id = db_notice.survey_id
+
+        # Create entries for each tile
         db_targets = []
         for tile_name, tile_weight in selected_tiles[('tilename', 'prob')]:
             # Find the matching GridTile
@@ -249,6 +291,8 @@ def add_to_database(notice, time=None, log=None):
             session.rollback()
             raise
 
+        return [target.db_id for target in db_targets]
+
 
 def handle_notice(notice, send_messages=False, log=None, time=None):
     """Handle a new transient notice.
@@ -299,7 +343,22 @@ def handle_notice(notice, send_messages=False, log=None, time=None):
                 log.exception('Error sending error report')
 
     log.info('Adding notice to the alert database')
-    add_to_database(notice, time=time, log=log)
+    # First, add the Notice to the alert database (and create a new Event if needed)
+    add_notice_to_database(notice)
+
+    # Then create a new Survey, deleting any previous targets if needed
+    survey_id = add_survey_to_database(notice, time, log)
+    if survey_id is None:
+        # We didn't add a new Survey, either it's a retraction or there have been no changes
+        if notice.strategy in ['IGNORE', ' RETRACTION'] or notice.strategy_dict is None:
+            log.info(f'{notice.strategy} notice processed')
+            return
+        else:
+            log.info('No changes to the skymap or strategy, so no update to the database required')
+            return
+
+    # Finally add the Targets
+    add_targets_to_database(notice, time, log)
 
     if send_messages:
         log.debug('Sending Slack observing report')

--- a/gtecs/alert/handler.py
+++ b/gtecs/alert/handler.py
@@ -7,6 +7,8 @@ from astropy.time import Time
 
 from gtecs.obs import database as obs_db
 
+import numpy as np
+
 from . import database as alert_db
 from .slack import send_notice_report, send_observing_report, send_slack_msg
 
@@ -21,12 +23,15 @@ def already_in_database(notice):
             return True
     return False
 
-def add_notice_to_database(notice):
+def add_notice_to_database(notice, log=None):
     """Add an entry for the given Notice to the alert database.
 
     If a matching Event already exists, the Notice will be linked to it.
     If not, a new Event will be created.
     """
+    if log is None:
+        log = logging.getLogger('database')
+        log.setLevel(level=logging.DEBUG)
 
     with alert_db.session_manager() as session:
         # Get any matching Event from the database, or make one if it's new
@@ -40,6 +45,9 @@ def add_notice_to_database(notice):
                 origin=notice.source,
                 time=notice.event_time,
             )
+            log.debug(f'Adding event {db_event.name} to database')
+        else:
+            log.debug(f'Matching to existing event {db_event.name}')
 
         # Make sure we have the notice skymap
         if notice.skymap is None:
@@ -61,6 +69,26 @@ def add_notice_to_database(notice):
                 raise
 
         return db_notice.db_id
+
+
+def delete_survey_targets(db_survey, time=None, log=None):
+    """Delete all Targets for the given Survey."""
+    if time is None:
+        time = Time.now()
+    if log is None:
+        log = logging.getLogger('database')
+        log.setLevel(level=logging.DEBUG)
+
+    with alert_db.session_manager() as session:
+        num_deleted = 0
+        for db_target in db_survey.targets:
+            statuses = ['deleted', 'expired', 'completed']
+            if db_target.status_at_time(time) not in statuses:
+                db_target.mark_deleted(time=time)
+                num_deleted += 1
+        if num_deleted > 0:
+            log.debug(f'Deleted {num_deleted} Targets for Survey {db_survey.name}')
+        session.commit()
 
 
 def add_survey_to_database(notice, time=None, log=None):
@@ -124,15 +152,7 @@ def add_survey_to_database(notice, time=None, log=None):
             # If there are multiple previous Surveys then all but the latest should have already
             # been deleted, but we might as well go through and check to be sure.
             for db_survey in db_event.surveys:
-                num_deleted = 0
-                for db_target in db_survey.targets:
-                    statuses = ['deleted', 'expired', 'completed']
-                    if db_target.status_at_time(time) not in statuses:
-                        db_target.mark_deleted(time=time)
-                        num_deleted += 1
-                if num_deleted > 0:
-                    log.debug(f'Deleted {num_deleted} Targets for Survey {db_survey.name}')
-                session.commit()
+                delete_survey_targets(db_survey, time, log)
 
         if notice.strategy in ['IGNORE', ' RETRACTION'] or notice.strategy_dict is None:
             # We've added the Notice to the database, but we don't need to add a new Survey.
@@ -147,7 +167,7 @@ def add_survey_to_database(notice, time=None, log=None):
         # Otherwise we know this notice has a new skymap (or strategy),
         # so we want to create a new Survey.
         db_survey = obs_db.Survey(name=f'{notice.event_name}_{len(db_event.surveys) + 1}')
-        log.debug('Adding Survey {} to database'.format(db_survey.name))
+        log.debug(f'Adding survey {db_survey.name} to database')
         session.add(db_survey)
         session.commit()
         survey_id = db_survey.db_id
@@ -156,6 +176,7 @@ def add_survey_to_database(notice, time=None, log=None):
         db_notice.survey_id = survey_id
 
     return survey_id
+
 
 def select_tiles(notice):
     """Select grid tiles for the given notice."""
@@ -176,6 +197,133 @@ def select_tiles(notice):
 
     return selected_tiles, grid
 
+
+def get_skymap_overlap(skymap1, skymap2, contour=0.95, regrade_nside=128):
+    """Get the overlap fraction between two skymaps at a given contour level.
+
+    TODO: This could be a method on the gototile.SkyMap class
+    """
+    # Regrade each skymap to the same nside
+    # TODO: It would be nice if it returned a new skymap (with inplace=False)
+    #       instead of modifying the original one.
+    if skymap1.nside != regrade_nside:
+        skymap1 = skymap1.copy()
+        skymap1.regrade(nside=regrade_nside)
+    if skymap2.nside != regrade_nside:
+        skymap2 = skymap2.copy()
+        skymap2.regrade(nside=regrade_nside)
+
+    # Get the pixel indices within the contour level
+    contour_ipix1 = set(np.where(skymap1.contours<contour)[0])
+    contour_ipix2 = set(np.where(skymap2.contours<contour)[0])
+    intersection = contour_ipix1.intersection(contour_ipix2)
+    if len(intersection) == 0:
+        return 0.0
+
+    # We want to return the biggest overlap fraction
+    # (i.e. the fraction of the smaller skymap that overlaps with the larger one)
+    return len(intersection) / min(len(contour_ipix1), len(contour_ipix2))
+
+
+def check_coincident_events(notice, time_window=10, skymap_contour=0.95, time=None, log=None):
+    """Check the AlertDB for any events with matching times and tile sets.
+
+    Returns True if a better event was found, False if not.
+
+    If any overlapping events are found we check which notice covers the fewest tiles.
+    If the new notice covers fewer tiles: delete the older notice and its targets,
+    and return False.
+    If the new notice covers the same or more tiles: keep the older targets and return True
+    (to signify no new Targets need to be added).
+
+    If no overlapping events are found then also return False.
+
+    """
+    if time is None:
+        time = Time.now()
+    if log is None:
+        log = logging.getLogger('database')
+        log.setLevel(level=logging.DEBUG)
+
+    # We should have already selected the tiles for this notice
+    if not hasattr(notice, 'selected_tiles'):
+        selected_tiles, _ = select_tiles(notice)
+    else:
+        selected_tiles = notice.selected_tiles
+    tile_set = set(selected_tiles['tilename'])
+
+    found_better_event = False
+    with alert_db.session_manager() as session:
+        # Get any Events from the database that have a matching event time
+        query = session.query(alert_db.Event)
+        query = query.filter(alert_db.Event.time >= notice.event_time - time_window * u.second)
+        query = query.filter(alert_db.Event.time <= notice.event_time + time_window * u.second)
+        query = query.filter(alert_db.Event.name != notice.event_name) # Don't include this event!
+        db_events = query.all()
+
+        # If there are no matching events then we just want to add this one, so return False
+        if len(db_events) == 0:
+            log.debug('No matching events found')
+            return found_better_event
+
+        log.debug(f'Found {len(db_events)} events within {time_window:.0f}s of {notice.event_time}')
+
+        # Now check if any of the events  overlap with this notice
+        # We want to check both the notice skymaps and the selected tiles,
+        # as either overlapping should trigger a match.
+        for db_event in db_events:
+            # We only care about the latest notice for each event,
+            # any previous ones should have already been deleted.
+            db_notice = db_event.notices[-1]
+            log.info(f'Coincident notice: {db_notice.ivorn}')
+            if len(db_notice.targets) == 0:
+                # No targets for this notice (might have been below min_prob), so we can ignore it
+                log.info('Notice has no targets defined')
+                continue
+
+            # Check if either of the notice skymaps overlap
+            skymap_overlap = get_skymap_overlap(
+                notice.skymap, db_notice.gcn.skymap, contour=skymap_contour
+            )
+            log.debug(f'Skymap overlap = {skymap_overlap > 0} ({skymap_overlap:.0%})')
+
+            # Check if any of the selected tiles overlap
+            old_tiles = [target.grid_tile.name for target in db_notice.targets]
+            old_tile_set = set(old_tiles)
+            tile_overlap = len(tile_set.intersection(old_tile_set))
+            tile_overlap /= min(len(tile_set), len(old_tile_set))
+            log.debug(f'Tile overlap = {tile_overlap > 0} ({tile_overlap:.0%})')
+
+            if tile_overlap == 0 and skymap_overlap == 0:
+                # Neither overlap, so the time must have been a coincidence
+                log.info('No overlap detected')
+                continue
+
+            # We have a match!
+            log.info('Overlap detected')
+
+            # Now we want to decide which notice is best to observe.
+            # It's not actually that obvious. We could compare the size of the skymaps or
+            # the number of tiles, but thanks to different selection limits you could have a
+            # case where a smaller skymap had more tiles added to the ObsDB.
+            # Easiest is just to go with the skymap area for which event better localised and
+            # therefore closer to the "real" position.
+            old_area = db_notice.gcn.skymap.get_contour_area(skymap_contour)
+            new_area = notice.skymap.get_contour_area(skymap_contour)
+            if new_area < old_area:
+                # This new notice is smaller, so we want to keep it and delete the old targets.
+                # If there are multiple previous Surveys then all but the latest should have already
+                # been deleted, but we might as well go through and check to be sure.
+                log.info('New notice skymap is smaller, deleting existing targets')
+                for db_survey in db_event.surveys:
+                    delete_survey_targets(db_survey, time, log)
+            else:
+                # The new notice is worse, so we want to ignore it and keep the existing targets.
+                log.info('New notice skymap is larger, leaving existing targets')
+                found_better_event = True
+
+        return found_better_event
+
 def add_targets_to_database(notice, time=None, log=None):
     """Add Targets for the given notice to the observation database.
 
@@ -189,9 +337,11 @@ def add_targets_to_database(notice, time=None, log=None):
         log = logging.getLogger('database')
         log.setLevel(level=logging.DEBUG)
 
-    log.debug('Selecting grid tiles')
-    selected_tiles, grid = select_tiles(notice)
-    log.debug('Selected {}/{} tiles'.format(len(selected_tiles), grid.ntiles))
+    # We should have already selected the tiles for this notice
+    if not hasattr(notice, 'selected_tiles'):
+        selected_tiles, _ = select_tiles(notice)
+    else:
+        selected_tiles = notice.selected_tiles
 
     # It's possible no tiles passed the selection criteria,
     # if so then there's nothing else to do.
@@ -283,7 +433,7 @@ def add_targets_to_database(notice, time=None, log=None):
             session.add(db_targets[-1])
 
         # Commit changes
-        log.debug('Adding {} Targets to the database'.format(len(db_targets)))
+        log.info(f'Adding {len(db_targets)} targets to the database')
         try:
             session.commit()
         except Exception:
@@ -320,7 +470,7 @@ def handle_notice(notice, send_messages=False, log=None, time=None):
     if time is None:
         time = Time.now()
 
-    log.info('Handling notice {}'.format(notice.ivorn))
+    log.info(f'Handling notice {notice.ivorn}')
 
     # Check if the notice is already in the database.
     # Do this before fetching the skymap to save time.
@@ -344,10 +494,10 @@ def handle_notice(notice, send_messages=False, log=None, time=None):
 
     log.info('Adding notice to the alert database')
     # First, add the Notice to the alert database (and create a new Event if needed)
-    add_notice_to_database(notice)
+    add_notice_to_database(notice, log=log)
 
     # Then create a new Survey, deleting any previous targets if needed
-    survey_id = add_survey_to_database(notice, time, log)
+    survey_id = add_survey_to_database(notice, time=time, log=log)
     if survey_id is None:
         # We didn't add a new Survey, either it's a retraction or there have been no changes
         if notice.strategy in ['IGNORE', ' RETRACTION'] or notice.strategy_dict is None:
@@ -357,8 +507,22 @@ def handle_notice(notice, send_messages=False, log=None, time=None):
             log.info('No changes to the skymap or strategy, so no update to the database required')
             return
 
-    # Finally add the Targets
-    add_targets_to_database(notice, time, log)
+    # Select the grid tiles for this notice
+    log.debug('Selecting grid tiles')
+    selected_tiles, grid = select_tiles(notice)
+    log.debug(f'Selected {len(selected_tiles)}/{grid.ntiles} tiles')
+    notice.selected_tiles = selected_tiles
+    notice.grid = grid
+
+    # Now check for overlaps
+    found_better_event = check_coincident_events(notice, time=time, log=log)
+    if found_better_event:
+        # There was a matching event in the database that covers fewer tiles,
+        # so we don't want to add this one.
+        log.info('Ignoring notice in favor of previous event')
+    else:
+        # Add new Targets for the survey
+        add_targets_to_database(notice, time=time, log=log)
 
     if send_messages:
         log.debug('Sending Slack observing report')
@@ -372,5 +536,5 @@ def handle_notice(notice, send_messages=False, log=None, time=None):
             except Exception:
                 log.exception('Error sending error report')
 
-    log.info('Notice {} successfully processed'.format(notice.ivorn))
+    log.info(f'Notice {notice.ivorn} successfully processed')
     return

--- a/gtecs/alert/handler.py
+++ b/gtecs/alert/handler.py
@@ -178,26 +178,6 @@ def add_survey_to_database(notice, time=None, log=None):
     return survey_id
 
 
-def select_tiles(notice):
-    """Select grid tiles for the given notice."""
-    with obs_db.session_manager() as session:
-        db_grid = obs_db.get_current_grid(session)
-        grid = db_grid.skygrid
-    grid_tiles = notice.get_tiles(grid)
-
-    # Select tiles within the skymap contour and above the minimum probability threshold
-    mask = ((grid_tiles['contour'] < notice.strategy_dict['skymap_contour']) &
-            (grid_tiles['prob'] > notice.strategy_dict['min_tile_prob']))
-    selected_tiles = grid_tiles[mask]
-    selected_tiles.sort('prob', reverse=True)
-
-    if len(selected_tiles) > notice.strategy_dict['max_tiles']:
-        # Limit to only the N highest probability tiles
-        selected_tiles = selected_tiles[:notice.strategy_dict['max_tiles']]
-
-    return selected_tiles, grid
-
-
 def get_skymap_overlap(skymap1, skymap2, contour=0.95, regrade_nside=128):
     """Get the overlap fraction between two skymaps at a given contour level.
 
@@ -246,10 +226,7 @@ def check_coincident_events(notice, time_window=10, skymap_contour=0.95, time=No
         log.setLevel(level=logging.DEBUG)
 
     # We should have already selected the tiles for this notice
-    if not hasattr(notice, 'selected_tiles'):
-        selected_tiles, _ = select_tiles(notice)
-    else:
-        selected_tiles = notice.selected_tiles
+    selected_tiles = notice.select_tiles()
     tile_set = set(selected_tiles['tilename'])
 
     found_better_event = False
@@ -338,10 +315,7 @@ def add_targets_to_database(notice, time=None, log=None):
         log.setLevel(level=logging.DEBUG)
 
     # We should have already selected the tiles for this notice
-    if not hasattr(notice, 'selected_tiles'):
-        selected_tiles, _ = select_tiles(notice)
-    else:
-        selected_tiles = notice.selected_tiles
+    selected_tiles = notice.select_tiles()
 
     # It's possible no tiles passed the selection criteria,
     # if so then there's nothing else to do.
@@ -509,10 +483,8 @@ def handle_notice(notice, send_messages=False, log=None, time=None):
 
     # Select the grid tiles for this notice
     log.debug('Selecting grid tiles')
-    selected_tiles, grid = select_tiles(notice)
-    log.debug(f'Selected {len(selected_tiles)}/{grid.ntiles} tiles')
-    notice.selected_tiles = selected_tiles
-    notice.grid = grid
+    selected_tiles = notice.select_tiles()
+    log.debug(f'Selected {len(selected_tiles)} tiles')
 
     # Now check for overlaps
     found_better_event = check_coincident_events(notice, time=time, log=log)

--- a/gtecs/alert/handler.py
+++ b/gtecs/alert/handler.py
@@ -442,7 +442,7 @@ def add_targets_to_database(notice, time=None, log=None):
         return [target.db_id for target in db_targets]
 
 
-def handle_notice(notice, send_messages=False, log=None, time=None):
+def handle_notice(notice, coincident_time_window=10, send_messages=False, log=None, time=None):
     """Handle a new transient notice.
 
     Parameters
@@ -450,6 +450,9 @@ def handle_notice(notice, send_messages=False, log=None, time=None):
     notice : `gtecs.alert.notices.Notice` or subclass
         The notice to handle
 
+    coincident_time_window : int, optional
+        Time window in seconds to check for coincident events.
+        Default is 10 s.
     send_messages : bool, optional
         If True, send Slack messages.
         Default is False.
@@ -511,7 +514,12 @@ def handle_notice(notice, send_messages=False, log=None, time=None):
     log.debug(f'Selected {len(selected_tiles)} tiles')
 
     # Now check for overlaps
-    found_better_event = check_coincident_events(notice, time=time, log=log)
+    found_better_event = check_coincident_events(
+        notice,
+        time_window=coincident_time_window,
+        time=time,
+        log=log,
+    )
     if found_better_event:
         # There was a matching event in the database that covers fewer tiles,
         # so we don't want to add this one.

--- a/gtecs/alert/handler.py
+++ b/gtecs/alert/handler.py
@@ -223,7 +223,13 @@ def get_tile_overlap(notice1, notice2):
     return len(intersection) / min(len(tile_set1), len(tile_set2))
 
 
-def find_coincident_events(notice, time_window=10, skymap_contour=0.95, type_limit=True):
+def find_coincident_events(
+        notice,
+        time_window=10,
+        skymap_contour=0.95,
+        type_limit=True,
+        return_parameters=False
+    ):
     """Check the AlertDB for any other events with matching times and positions.
 
     Parameters
@@ -240,12 +246,23 @@ def find_coincident_events(notice, time_window=10, skymap_contour=0.95, type_lim
     type_limit : bool, optional
         If True, only check for events of the same type as the given notice.
         Default is True.
+    return_parameters : bool, optional
+        If True, return the time difference, skymap overlap, and tile overlap
+        for each matching event.
+        Default is False.
+        If False, only return the matching event IDs.
 
     Returns
     -------
-    matching_events : list of int
-        A list of database IDs for any matching events.
+    matching_events : list of int or list of tuples
+        If `return_parameters` is False, a list of database IDs for any matching events.
+        If `return_parameters` is True, a list of tuples containing the database ID,
+        time difference, skymap overlap, and tile overlap for each matching event.
+        Each tuple is of the form (db_id, time_diff, skymap_overlap, tile_overlap).
+        The time difference is in seconds, and the skymap and tile overlaps are fractions
+        between 0 and 1.
         If no matches are found, an empty list is returned.
+
     """
     with alert_db.session_manager() as session:
         # Get any Events from the database that have a matching event time
@@ -269,6 +286,7 @@ def find_coincident_events(notice, time_window=10, skymap_contour=0.95, type_lim
             # We only care about the latest notice for each event,
             # any previous ones should have already been deleted.
             event_notice = db_event.notices[-1].gcn
+            time_diff = (event_notice.event_time - notice.event_time).value
 
             # Check if either of the notice skymaps or tilesets overlap
             skymap_overlap = get_skymap_overlap(
@@ -280,7 +298,17 @@ def find_coincident_events(notice, time_window=10, skymap_contour=0.95, type_lim
                 continue
 
             # We have a match!
-            matching_events.append(db_event.db_id)
+            if return_parameters:
+                params = (
+                    db_event.db_id,
+                    time_diff,
+                    skymap_overlap,
+                    tile_overlap
+                )
+                matching_events.append(params)
+            else:
+                # Just append the event ID
+                matching_events.append(db_event.db_id)
 
     return matching_events
 
@@ -306,7 +334,7 @@ def check_coincident_events(notice, time_window=10, skymap_contour=0.95, time=No
 
     # Find any overlapping events
     coincident_events = find_coincident_events(
-        notice, time_window=time_window, skymap_contour=skymap_contour
+        notice, time_window=time_window, skymap_contour=skymap_contour, return_parameters=True
     )
     if len(coincident_events) == 0:
         # No matching events found, so nothing to do
@@ -318,7 +346,10 @@ def check_coincident_events(notice, time_window=10, skymap_contour=0.95, time=No
     # are "better" than this one.
     with alert_db.session_manager() as session:
         found_better = False
-        for db_event_id in coincident_events:
+        for event_parameters in coincident_events:
+            # Get the event ID and parameters
+            db_event_id, time_diff, skymap_overlap, tile_overlap = event_parameters
+
             # Get the event ant latest notice from the database
             db_event = session.query(alert_db.Event).filter_by(db_id=db_event_id).one()
             event_notice = db_event.notices[-1].gcn
@@ -331,17 +362,11 @@ def check_coincident_events(notice, time_window=10, skymap_contour=0.95, time=No
                 log.info('Notice has no targets defined')
                 continue
 
-            # Get the parameters
-            # Yes this is duplicating what happens in find_coincident_notices(),
-            # but that doesn't include logging.
-            time_diff = abs(event_notice.event_time - notice.event_time)
-            skymap_overlap = get_skymap_overlap(
-                notice.skymap, event_notice.skymap, contour=skymap_contour
-            )
-            tile_overlap = get_tile_overlap(notice, event_notice)
-            log.debug(f'Time difference: {time_diff.value:.1f}s')
+            log.debug(f'Time difference: {time_diff:.3f}s')
             log.debug(f'Skymap overlap: {skymap_overlap:.0%}')
             log.debug(f'Tile overlap: {tile_overlap:.0%}')
+
+            # TODO: ADD SLACK MESSAGE
 
             # Now we want to decide which notice is best to observe.
             # It's not actually that obvious. We could compare the size of the skymaps or

--- a/gtecs/alert/notices.py
+++ b/gtecs/alert/notices.py
@@ -467,6 +467,17 @@ class Notice:
     @property
     def strategy(self):
         """Get the observing strategy key."""
+        if not hasattr(self, '_strategy'):
+            self._strategy = self.get_strategy()
+        return self._strategy
+
+    @strategy.setter
+    def strategy(self, value):
+        """Override the default observing strategy key."""
+        self._strategy = value
+
+    def get_strategy(self):
+        """Get the observing strategy key."""
         return 'DEFAULT'
 
     @staticmethod
@@ -904,6 +915,11 @@ class GWNotice(Notice):
             self._strategy = self.get_strategy()
         return self._strategy
 
+    @strategy.setter
+    def strategy(self, value):
+        """Override the default observing strategy key."""
+        self._strategy = value
+
     def get_strategy(self):
         """Get the observing strategy key."""
         if self.skymap is None:
@@ -1186,6 +1202,17 @@ class GWRetractionNotice(Notice):
     @property
     def strategy(self):
         """Get the observing strategy key."""
+        if not hasattr(self, '_strategy'):
+            self._strategy = self.get_strategy()
+        return self._strategy
+
+    @strategy.setter
+    def strategy(self, value):
+        """Override the default observing strategy key."""
+        self._strategy = value
+
+    def get_strategy(self):
+        """Get the observing strategy key."""
         return 'RETRACTION'
 
     @property
@@ -1267,6 +1294,17 @@ class FermiNotice(Notice):
 
     @property
     def strategy(self):
+        """Get the observing strategy key."""
+        if not hasattr(self, '_strategy'):
+            self._strategy = self.get_strategy()
+        return self._strategy
+
+    @strategy.setter
+    def strategy(self, value):
+        """Override the default observing strategy key."""
+        self._strategy = value
+
+    def get_strategy(self):
         """Get the observing strategy key."""
         if self.skymap is None:
             # We need the skymap to know the area
@@ -1350,6 +1388,17 @@ class SwiftNotice(Notice):
     @property
     def strategy(self):
         """Get the observing strategy key."""
+        if not hasattr(self, '_strategy'):
+            self._strategy = self.get_strategy()
+        return self._strategy
+
+    @strategy.setter
+    def strategy(self, value):
+        """Override the default observing strategy key."""
+        self._strategy = value
+
+    def get_strategy(self):
+        """Get the observing strategy key."""
         return 'GRB_SWIFT'
 
     @property
@@ -1418,6 +1467,17 @@ class GECAMNotice(Notice):
     @property
     def strategy(self):
         """Get the observing strategy key."""
+        if not hasattr(self, '_strategy'):
+            self._strategy = self.get_strategy()
+        return self._strategy
+
+    @strategy.setter
+    def strategy(self, value):
+        """Override the default observing strategy key."""
+        self._strategy = value
+
+    def get_strategy(self):
+        """Get the observing strategy key."""
         return 'GRB_OTHER'
 
     @property
@@ -1479,6 +1539,17 @@ class EinsteinProbeNotice(Notice):
 
     @property
     def strategy(self):
+        """Get the observing strategy key."""
+        if not hasattr(self, '_strategy'):
+            self._strategy = self.get_strategy()
+        return self._strategy
+
+    @strategy.setter
+    def strategy(self, value):
+        """Override the default observing strategy key."""
+        self._strategy = value
+
+    def get_strategy(self):
         """Get the observing strategy key."""
         return 'GRB_OTHER'
 
@@ -1570,6 +1641,17 @@ class SVOMNotice(Notice):
     @property
     def strategy(self):
         """Get the observing strategy key."""
+        if not hasattr(self, '_strategy'):
+            self._strategy = self.get_strategy()
+        return self._strategy
+
+    @strategy.setter
+    def strategy(self, value):
+        """Override the default observing strategy key."""
+        self._strategy = value
+
+    def get_strategy(self):
+        """Get the observing strategy key."""
         if self.instrument == 'ECLAIRs':
             # ECLAIRs has a narrow field of view, so we use the Swift strategy
             return 'GRB_SWIFT'
@@ -1651,6 +1733,17 @@ class IceCubeNotice(Notice):
 
     @property
     def strategy(self):
+        """Get the observing strategy key."""
+        if not hasattr(self, '_strategy'):
+            self._strategy = self.get_strategy()
+        return self._strategy
+
+    @strategy.setter
+    def strategy(self, value):
+        """Override the default observing strategy key."""
+        self._strategy = value
+
+    def get_strategy(self):
         """Get the observing strategy key."""
         if self.type == 'ASTROTRACK_GOLD':
             return 'NU_ICECUBE_GOLD'

--- a/gtecs/alert/notices.py
+++ b/gtecs/alert/notices.py
@@ -479,7 +479,9 @@ class Notice:
     @property
     def strategy_dict(self):
         """Get the observing strategy details."""
-        return self.get_strategy_details(self.strategy, time=self.event_time)
+        if not hasattr(self, '_strategy_dict'):
+            self._strategy_dict = self.get_strategy_details(self.strategy)
+        return self._strategy_dict
 
     @property
     def slack_details(self):

--- a/gtecs/alert/notices.py
+++ b/gtecs/alert/notices.py
@@ -240,6 +240,7 @@ class Notice:
         self.skymap_file = None
         self._grid = None
         self.grid_tiles = None
+        self.selected_tiles = None
 
     def __repr__(self):
         return '{}(ivorn={})'.format(self.__class__.__name__, self.ivorn)
@@ -390,8 +391,6 @@ class Notice:
 
     def get_tiles(self, grid=None, regrade_nside=128):
         """Apply the skymap for this notice to the given grid."""
-        if self.skymap is None:
-            raise ValueError('Cannot select tiles without a skymap')
         if self.grid_tiles is not None and (grid is None or self._grid == grid):
             return self.grid_tiles
 
@@ -404,6 +403,10 @@ class Notice:
                     grid = db_grid.skygrid
             except Exception:
                 raise ValueError('No grid provided and cannot get current grid from ObsDB')
+
+        # We need a skymap to select tiles
+        if self.skymap is None:
+            raise ValueError('Cannot select tiles without a skymap')
 
         # If the skymap is too big we regrade before applying it to the grid
         skymap = self.skymap.copy()
@@ -419,7 +422,47 @@ class Notice:
         self._grid = grid.copy()
         self.grid_tiles = grid_tiles.copy()
 
-        return grid_tiles
+        return self.grid_tiles
+
+    def select_tiles(self, grid=None):
+        """Select grid tiles for this notice using the strategy limits."""
+        if self.selected_tiles is not None and (grid is None or self._grid == grid):
+            return self.selected_tiles
+
+        if grid is None or not isinstance(grid, SkyGrid):
+            # If we're not given a grid, try getting it from the ObsDB
+            try:
+                from gtecs.obs import database as obs_db
+                with obs_db.session_manager() as session:
+                    db_grid = obs_db.get_current_grid(session)
+                    grid = db_grid.skygrid
+            except Exception:
+                raise ValueError('No grid provided and cannot get current grid from ObsDB')
+
+        # Get the full tile table (this will require the skymap, and will also cache the grid)
+        grid_tiles = self.get_tiles(grid)
+
+        # We need a strategy to select tiles, retraction or ignore notices won't have one.
+        # Retractions will have already failed to get the skymap above, so this is just
+        # if we're ignoring the notice.
+        # We could raise an error, but returning an empty table seems cleaner.
+        if self.strategy_dict is None:
+            return grid_tiles[0:0]
+
+        # Select tiles within the skymap contour and above the minimum probability threshold
+        mask = ((grid_tiles['contour'] < self.strategy_dict['skymap_contour']) &
+                (grid_tiles['prob'] > self.strategy_dict['min_tile_prob']))
+        selected_tiles = grid_tiles[mask]
+        selected_tiles.sort('prob', reverse=True)
+
+        if len(selected_tiles) > self.strategy_dict['max_tiles']:
+            # Limit to only the N highest probability tiles
+            selected_tiles = selected_tiles[:self.strategy_dict['max_tiles']]
+
+        # Cache the selected tiles to save time for future calls
+        self.selected_tiles = selected_tiles.copy()
+
+        return self.selected_tiles
 
     @property
     def strategy(self):
@@ -952,6 +995,10 @@ class GWNotice(Notice):
             is the main factor. We could consider the exposure time per tile, but assuming that's
             constant (aside from slew time) it's not really necessary.
             Basic rule of thumb is 5 minutes per tile, so 120 tiles in an average 10 hour night.
+
+            And note we just filter the full tile list, not the notice.selected_tiles() which
+            requires the notice strategy. Obviously at this point we're trying to decide the
+            strategy, so we can't use that here!
 
             """
             grid_tiles = notice.get_tiles()

--- a/gtecs/alert/params.py
+++ b/gtecs/alert/params.py
@@ -41,7 +41,8 @@ KAFKA_BROKER = config['KAFKA_BROKER']
 KAFKA_GROUP_ID = config['KAFKA_GROUP_ID']
 KAFKA_BACKDATE = config['KAFKA_BACKDATE']
 
-# Filter parameters
+# Alert handling parameters
+COINCIDENT_TIME_WINDOW = config['COINCIDENT_TIME_WINDOW']
 # TODO: Couldn't this be a switchable flag within the sentinel?
 PROCESS_TEST_NOTICES = config['PROCESS_TEST_NOTICES']
 

--- a/gtecs/alert/sentinel.py
+++ b/gtecs/alert/sentinel.py
@@ -439,7 +439,12 @@ class Sentinel:
                         continue
 
                     send_slack_msg(f'Sentinel processing new notice ({notice.ivorn})')
-                    handle_notice(notice, send_messages=params.ENABLE_SLACK, log=self.log)
+                    handle_notice(
+                        notice,
+                        coincident_time_window=params.COINCIDENT_TIME_WINDOW,
+                        send_messages=params.ENABLE_SLACK,
+                        log=self.log
+                    )
                     self.processed_notices += 1
                     send_slack_msg('Sentinel successfully processed notice')
 

--- a/gtecs/alert/slack.py
+++ b/gtecs/alert/slack.py
@@ -245,6 +245,7 @@ def send_observing_report(notice, time=None):
     msg = f'*{notice.source} notice:* {notice.ivorn}\n'
 
     # Get info from the alert database
+    coincidence_events = {}
     with alert_db.session_manager() as session:
         # Query the Notice table for the matching entry
         query = session.query(alert_db.Notice).filter(alert_db.Notice.ivorn == notice.ivorn)
@@ -275,6 +276,24 @@ def send_observing_report(notice, time=None):
         if len(running) > 0:
             msg += f' ({len(running)} are currently being observed)'
         msg += '\n'
+
+        # Check if the event is part of a coincidence group
+        if db_event.coincidence is not None:
+            db_coincidence = db_event.coincidence
+            msg += '*Event is part of a coincidence group!*\n'
+            msg += f'Coincidence group (ID={db_coincidence.db_id})'
+            msg += f' contains {len(db_coincidence.events)} events:\n'
+            for matched_event in db_coincidence.events:
+                msg += f'- `{matched_event.name}`: '
+                scheduled = [
+                    t for survey in matched_event.surveys for t in survey.targets
+                    if t.scheduled_at_time(status_time)
+                ]
+                msg += f'{len(scheduled)} scheduled targets'
+                msg += f' (ID={matched_event.db_id})\n'
+                coincidence_events[matched_event.name] = len(scheduled)
+            if sum(scheduled != 0 for scheduled in coincidence_events.values()) > 1:
+                msg += '*ERROR: Multiple events in coincidence group have scheduled targets!*\n'
 
         # Look at the Survey this Notice is linked to (if any)
         db_survey = db_notice.survey
@@ -324,10 +343,13 @@ def send_observing_report(notice, time=None):
     if len(survey_tiles) == 0:
         # This might be because no tiles passed the filter
         if (notice.strategy_dict['min_tile_prob'] > 0 and
-                max(grid.prob) < notice.strategy_dict['min_tile_prob']):
+                max(grid.probs) < notice.strategy_dict['min_tile_prob']):
             msg += '- No tiles passed the probability limit '
             msg += f'({notice.strategy_dict["min_tile_prob"]:.1%}, '
-            msg += f'highest had {max(grid.prob):.1%})\n'
+            msg += f'highest had {max(grid.probs):.1%})\n'
+        # Or it might be because this event was matched to a better one already in the database
+        if len(coincidence_events) > 1 and coincidence_events[notice.event_name] == 0:
+            msg += '- Event was matched to a better existing event\n'
         else:
             # Uh-oh, something went wrong when inserting?
             msg += '- *ERROR: No targets found in database*\n'

--- a/gtecs/alert/tests/test_coincidence.py
+++ b/gtecs/alert/tests/test_coincidence.py
@@ -1,0 +1,23 @@
+from gtecs.alert import handler, notices
+
+n1 = notices.Notice.from_file(
+    "/home/martin/Dropbox/GOTO/0_code/gtecs-alert/gtecs/alert/data/test_notices/Fermi/730284696-GBM_FIN_POS-GRB_240222A.json"
+)
+n2 = notices.Notice.from_file(
+    "/home/martin/Dropbox/GOTO/0_code/gtecs-alert/gtecs/alert/data/test_notices/Swift/1216804-BAT_GRB_POS-GRB_240222A.json"
+)
+n3 = notices.Notice.from_file(
+    "/home/martin/Dropbox/GOTO/0_code/gtecs-alert/gtecs/alert/data/test_notices/GECAM/297-FLT-GRB_240222A.json"
+)
+n3.strategy_dict["min_tile_prob"] = 0.001  # To ensure tiles are actually selected
+
+print('~~~~~~')
+print(n1)
+handler.handle_notice(n1, send_messages=False)
+print('~~~~~~')
+print(n2)
+handler.handle_notice(n2, send_messages=False)
+print('~~~~~~')
+print(n3)
+handler.handle_notice(n3, send_messages=False)
+print('~~~~~~')

--- a/scripts/find_coincidences
+++ b/scripts/find_coincidences
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Search the AlertDB for coincident events."""
+
+from gtecs.alert import database as db
+from gtecs.alert import notices
+from gtecs.alert.coincidence import find_coincident_events
+
+
+
+def run(time_window=10, skymap_contour=0.95):
+    with db.session_manager() as session:
+        # Get all GRB events from the database
+        db_events = session.query(db.Event).filter(db.Event.type == 'GRB').all()
+        db_events.sort(key=lambda x: x.time)
+        print('Found', len(db_events), 'GRB events')
+
+        # Loop through all events and find coincidences
+        for i, db_event in enumerate(db_events):
+            print(f'Processing event {i+1}/{len(db_events)}: {db_event.name} (db_id={db_event.db_id})')
+
+            # Check if we already have a coincidence group for this event
+            if db_event.coincidence is not None:
+                print(f'  - Already in Coincidence group {db_event.coincidence.db_id}')
+                continue
+
+            # Loop through all notices for this event
+            for db_notice in db_event.notices:
+                notice = db_notice.gcn
+                if type(notice) == notices.Notice:
+                    # Should be a subclass, must be invalid for some reason?
+                    # E.g. ivo://nasa.gsfc.gcn/SWIFT#BAT_GRB_Pos_1180055-466
+                    # is in the database but has a bad star lock
+                    print(f'  - Skipping notice (invalid type)')
+                    continue
+
+                # Find any coincident events
+                coincident_events = find_coincident_events(
+                    notice,
+                    time_window=time_window,
+                    skymap_contour=skymap_contour,
+                    return_parameters=False,
+                )
+                if len(coincident_events) == 0:
+                    continue
+
+                # We found a coincidence!
+                print(f'Found {len(coincident_events)} coincident events')
+
+                # What if this event is already in a group?
+                # We're looping through all notices, so we might have already
+                # added it from a previous notice.
+                if db_event.coincidence is not None:
+                    db_coincidence = db_event.coincidence
+                    print(f'  - Already in Coincidence group {db_coincidence.db_id}')
+                else:
+                    # Create a new Coincidence group
+                    print(f'  - Creating new Coincidence group')
+                    db_coincidence = db.Coincidence()
+                    session.add(db_coincidence)
+                    session.commit()
+
+                # Add the original and matched events to the group
+                db_event.coincidence = db_coincidence
+                for matched_id in coincident_events:
+                    matched_event = session.get(db.Event, matched_id)
+                    print(f'  - Adding {matched_event.name} to Coincidence group {db_coincidence.db_id}')
+                    matched_event.coincidence = db_coincidence
+
+                print(f'  - Coincidence group {db_coincidence.db_id} has {len(db_coincidence.events)} events')
+
+        # Now go through all Coincidence groups
+        db_coincidences = session.query(db.Coincidence).all()
+        print(f'Found {len(db_coincidences)} Coincidence groups')
+        for db_coincidence in db_coincidences:
+            print(f'Coincidence group {db_coincidence.db_id} has {len(db_coincidence.events)} events:')
+            for event in db_coincidence.events:
+                print(f'  - {event.name:<30} (db_id={event.db_id:>4}), {event.time}')
+
+
+if __name__ == "__main__":
+    run()

--- a/scripts/setup_alertdb
+++ b/scripts/setup_alertdb
@@ -98,10 +98,15 @@ def clear_database(schema_name, base, verbose=False):
         with db.session_manager() as session:
             # Delete from tables in dependency order
             for table_name in table_names:
-                result = session.execute(text(f"DELETE FROM {schema_name}.{table_name}"))
-                if result.rowcount > 0 and verbose:
-                    print(f"  Cleared {result.rowcount} rows from {table_name}")
+                # Count rows first for verbose output
+                if verbose:
+                    row_count = session.execute(text(f"SELECT COUNT(*) FROM {schema_name}.{table_name}")).scalar()
+                    if row_count > 0:
+                        print(f"  Clearing {row_count} rows from {table_name}")
+                # TRUNCATE automatically resets sequences with RESTART IDENTITY
+                session.execute(text(f"TRUNCATE TABLE {schema_name}.{table_name} RESTART IDENTITY CASCADE"))
             session.commit()
+
     except Exception as e:
         session.rollback()
 


### PR DESCRIPTION
This PR finally adds in detections for GRB events from different sources that refer to the same astrophysical event.

There's a lot more details into the development in https://github.com/GOTO-OBS/gtecs-alert/issues/11, but in short when a notice comes in a search will be done for any matching notices of the same class that fall within a set time window (10s by default). If a temporal match is found then the skymaps for both events are compared, and if they overlap (either in terms of skymap contours or tiles - see https://github.com/GOTO-OBS/gtecs-alert/issues/11#issuecomment-2809529255 for the complexities) then they are deemed to be "coincident". 

The logic for handling coincident events is deliberately simple: whichever notice has the best localisation is selected as the "preferred" notice, and the other is either deleted and replaced (if the better notice came in second) or ignored (if the better notice was already received). There's no event to combine skymaps or develop a new strategy. That could be something interesting, especially if we wanted to combine GW and GRB alerts as discussed in #29. But it would be a whole extra project, and this has been delayed enough.