### PR TITLE
Raise Swift GRB rank above GW rank 3 & 4

### DIFF
--- a/gtecs/alert/data/strategies.json
+++ b/gtecs/alert/data/strategies.json
@@ -141,7 +141,7 @@
         "wakeup_alert": 1
     },
     "GW_RANK_3_WIDE": {
-        "rank": 33,
+        "rank": 133,
         "valid_hours": 72,
         "cadence": {
             "num_todo": 99,
@@ -172,7 +172,7 @@
         "max_tiles": 200
     },
     "GW_RANK_3_NARROW": {
-        "rank": 33,
+        "rank": 133,
         "valid_hours": 72,
         "cadence": {
             "num_todo": 99,
@@ -197,7 +197,7 @@
         "max_tiles": 200
     },
     "GW_RANK_4_WIDE": {
-        "rank": 344,
+        "rank": 1044,
         "valid_hours": 72,
         "cadence": {
             "num_todo": 12,
@@ -228,7 +228,7 @@
         "max_tiles": 200
     },
     "GW_RANK_4_NARROW": {
-        "rank": 344,
+        "rank": 1044,
         "valid_hours": 72,
         "cadence": {
             "num_todo": 12,
@@ -256,7 +256,7 @@
         "max_tiles": 200
     },
     "GRB_SWIFT": {
-        "rank": 207,
+        "rank": 107,
         "valid_hours": 2,
         "cadence": {
             "num_todo": 2,

--- a/gtecs/alert/notices.py
+++ b/gtecs/alert/notices.py
@@ -1551,7 +1551,7 @@ class EinsteinProbeNotice(Notice):
 
     def get_strategy(self):
         """Get the observing strategy key."""
-        return 'GRB_OTHER'
+        return 'GRB_SWIFT'
 
     @property
     def slack_details(self):


### PR DESCRIPTION
_This was changed and set live on 9 September 2025, but never committed._

Basically, Rank 3 and 4s were too low priority and took up too much time compared to the possibility for science results from quick follow-up of well-localised GRB alerts.

At the same time, EP alerts are formally moved onto the GRB_SWIFT strategy.

See discussions in the scheduling channel for details.